### PR TITLE
fix: resolve maintainerr deployment failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .private/
 .task/
+.grok/
 *.crt
 *.key
 .decrypted~*

--- a/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
@@ -8,6 +8,7 @@ spec:
   chartRef:
     kind: OCIRepository
     name: app-template
+    namespace: flux-system
   interval: 15m
   dependsOn: []
   values:
@@ -26,8 +27,7 @@ spec:
           app:
             image:
               repository: ghcr.io/maintainerr/maintainerr
-              tag:
-                3.8.0@sha256:014fcae5d4cfae96bfb239ebe9368751549e9516947435f4e07520add92cf19e
+              tag: 3.8.0@sha256:014fcae5d4cfae96bfb239ebe9368751549e9516947435f4e07520add92cf19e
             env:
               TZ: America/Edmonton
             probes:


### PR DESCRIPTION
## Summary
- Add missing `namespace: flux-system` to `chartRef` in Maintainerr HelmRelease — Flux was looking for the `app-template` OCIRepository in the `media` namespace where it does not exist
- Fix malformed image `tag` field (was a multi-line scalar, now inline string)
- Updated `.gitignore`

## Test plan
- [ ] Verify Maintainerr HelmRelease reconciles successfully after merge
- [ ] Confirm Maintainerr pod starts in the `media` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)