### PR TITLE
fix(outline): replace yarn invocations with direct node calls for 1.7.1

### DIFF
--- a/kubernetes/apps/default/outline/app/helmrelease.yaml
+++ b/kubernetes/apps/default/outline/app/helmrelease.yaml
@@ -33,17 +33,35 @@ spec:
             envFrom:
               - secretRef:
                   name: outline-initdb-secret
-        containers:
-          app:
+          02-migrate:
             image:
               repository: docker.io/outlinewiki/outline
-              tag: 1.1.0@sha256:51db3e893d3eabdbf9092712c9c8ed5362efb20e4c1d35b941ccacaed1c0f010
-            command: ["/bin/sh", "-c", "yarn db:migrate --env=production-ssl-disabled && yarn start --env=production-ssl-disabled"]
+              tag: 1.7.1@sha256:361df7040e6f0d7abac768b99f40122197921626a7e69501aabb5fcb496fc1b4
+            command: ["node", "./node_modules/.bin/sequelize", "db:migrate", "--env=production-ssl-disabled"]
             env:
               DATABASE_URL:
                 valueFrom:
                   secretKeyRef:
                     name: &pguser outline-pguser-secret
+                    key: uri
+            envFrom:
+              - secretRef:
+                  name: outline-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+        containers:
+          app:
+            image:
+              repository: docker.io/outlinewiki/outline
+              tag: 1.7.1@sha256:361df7040e6f0d7abac768b99f40122197921626a7e69501aabb5fcb496fc1b4
+            command: ["node", "./build/server/index.js", "--env=production-ssl-disabled"]
+            env:
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: *pguser
                     key: uri
             envFrom:
               - secretRef:
@@ -61,9 +79,9 @@ spec:
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 100
-        fsGroup: 100
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
         fsGroupChangePolicy: OnRootMismatch
     service:
       app:


### PR DESCRIPTION
## Summary
- Outline 1.7.x added `"packageManager": "yarn@4.11.0"` to package.json (outline/outline#10719), causing the base image's global Yarn 1.22.22 to refuse to run without Corepack
- Drop the yarn-based shell command and call `node ./build/server/index.js` directly, mirroring upstream's CMD
- Move migrations into a dedicated `02-migrate` initContainer that invokes `sequelize-cli` directly
- Align `runAsUser`/`runAsGroup`/`fsGroup` to `1001` to match the image's `nodejs` user

## Test plan
- [ ] flux-local CI validates manifest
- [ ] After merge, watch `kubectl -n default get pods -l app.kubernetes.io/name=outline -w`
- [ ] Confirm `02-migrate` initContainer exits 0 with no yarn/Corepack errors
- [ ] Confirm app container boots (`kubectl -n default logs -f -l app.kubernetes.io/name=outline -c app`)
- [ ] Hit https://outline.pipitonelabs.com — login + load a doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)