### PR TITLE
chore: promote MutatingAdmissionPolicy to v1 for Talos 1.13

### DIFF
--- a/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.0/mutatingadmissionpolicybinding-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: volsync-mover-jitter
@@ -8,7 +8,7 @@ spec:
   policyName: volsync-mover-jitter
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.0/mutatingadmissionpolicy-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: volsync-mover-jitter
@@ -54,7 +54,7 @@ spec:
           ]
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.0/mutatingadmissionpolicybinding-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: volsync-mover-nfs
@@ -62,7 +62,7 @@ spec:
   policyName: volsync-mover-nfs
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.0/mutatingadmissionpolicy-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: volsync-mover-nfs

--- a/kubernetes/apps/volsync-system/volsync/maintenance/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/mutatingadmissionpolicy.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.0/mutatingadmissionpolicybinding-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: kopia-maintenance-nfs
@@ -8,7 +8,7 @@ spec:
   policyName: kopia-maintenance-nfs
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.0/mutatingadmissionpolicy-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: kopia-maintenance-nfs

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -159,8 +159,7 @@ cluster:
   apiServer:
     extraArgs:
       enable-aggregator-routing: "true"
-      feature-gates: ImageVolume=true,MutatingAdmissionPolicy=true,ResourceHealthStatus=true
-      runtime-config: admissionregistration.k8s.io/v1beta1=true
+      feature-gates: ImageVolume=true,ResourceHealthStatus=true
     certSANs:
       - k8s.internal
     disablePodSecurityPolicy: true


### PR DESCRIPTION
## Summary
- `MutatingAdmissionPolicy` graduates to GA (v1) in Kubernetes 1.36, which ships with Talos 1.13.
- Drop `runtime-config: admissionregistration.k8s.io/v1beta1=true` and the `MutatingAdmissionPolicy=true` feature gate from `talos/machineconfig.yaml.j2` — both become defaults in 1.36.
- Migrate the remaining `v1beta1` `MutatingAdmissionPolicy` / `MutatingAdmissionPolicyBinding` manifests in `volsync-system` to `v1`.

## Test plan
- [ ] flux-local validation passes
- [ ] After merge / Talos 1.13 upgrade, confirm volsync mover and kopia maintenance jobs still get the expected mutations applied
- [ ] No API server warnings about deprecated v1beta1 resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)