### PR TITLE
fix(app-template): move ResourceClaimTemplates out of rawResources for 5.0.0 compat

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -62,18 +62,6 @@ spec:
         ports:
           http:
             port: 11434
-    rawResources:
-      gpu:
-        apiVersion: resource.k8s.io/v1
-        kind: ResourceClaimTemplate
-        spec:
-          spec:
-            spec:
-              devices:
-                requests:
-                  - name: gpu
-                    exactly:
-                      deviceClassName: gpu.intel.com
     route:
       app:
         hostnames: ["{{ .Release.Name }}.pipitonelabs.com"]

--- a/kubernetes/apps/ai/ollama/app/kustomization.yaml
+++ b/kubernetes/apps/ai/ollama/app/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./resourceclaimtemplate.yaml

--- a/kubernetes/apps/ai/ollama/app/resourceclaimtemplate.yaml
+++ b/kubernetes/apps/ai/ollama/app/resourceclaimtemplate.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: ollama
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com

--- a/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
+++ b/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
@@ -72,18 +72,6 @@ spec:
         ports:
           http:
             port: *port
-    rawResources:
-      gpu:
-        apiVersion: resource.k8s.io/v1
-        kind: ResourceClaimTemplate
-        spec:
-          spec:
-            spec:
-              devices:
-                requests:
-                  - name: gpu
-                    exactly:
-                      deviceClassName: gpu.intel.com
     route:
       app:
         annotations:

--- a/kubernetes/apps/media/pinchflat/app/kustomization.yaml
+++ b/kubernetes/apps/media/pinchflat/app/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./resourceclaimtemplate.yaml

--- a/kubernetes/apps/media/pinchflat/app/resourceclaimtemplate.yaml
+++ b/kubernetes/apps/media/pinchflat/app/resourceclaimtemplate.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: pinchflat
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -85,18 +85,6 @@ spec:
                 subPath: transcode
               - path: /tmp
                 subPath: tmp
-    rawResources:
-      gpu:
-        apiVersion: resource.k8s.io/v1
-        kind: ResourceClaimTemplate
-        spec:
-          spec:
-            spec:
-              devices:
-                requests:
-                  - name: gpu
-                    exactly:
-                      deviceClassName: gpu.intel.com
     route:
       app:
         annotations:

--- a/kubernetes/apps/media/plex/app/kustomization.yaml
+++ b/kubernetes/apps/media/plex/app/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./pvc.yaml
+  - ./resourceclaimtemplate.yaml

--- a/kubernetes/apps/media/plex/app/resourceclaimtemplate.yaml
+++ b/kubernetes/apps/media/plex/app/resourceclaimtemplate.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: plex
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com


### PR DESCRIPTION
## Summary

- app-template 5.0.0 changed the `rawResources` schema to require a `manifest` wrapper key, breaking `plex`, `pinchflat`, and `ollama` with schema validation errors
- Moves each `ResourceClaimTemplate` into a standalone Kustomize-managed file (same pattern used by [buroa/k8s-gitops](https://github.com/buroa/k8s-gitops/blob/main/kubernetes/apps/media/plex/app/resourceclaimtemplate.yaml)) instead of embedding in `rawResources`
- Removes the `rawResources` block from all three HelmReleases

## Note

`external-dns-cloudflare` and `external-dns-unifi` are also failing due to their ServiceAccounts being deleted during the Helm 4→5 upgrade cycle. No code changes needed — force-reconcile after merge:
```bash
flux reconcile kustomization -n networking external-dns-cloudflare --with-source
flux reconcile kustomization -n networking external-dns-unifi --with-source
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)