### PR TITLE
fix(external-dns): fix SA ownership and automountServiceAccountToken for app-template 5.0.0

### DIFF
--- a/kubernetes/apps/networking/external-dns/cloudflare/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/cloudflare/helmrelease.yaml
@@ -63,7 +63,7 @@ spec:
         serviceAccount:
           name: *app
     defaultPodOptions:
-      hostUsers: false
+      automountServiceAccountToken: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/networking/external-dns/cloudflare/rbac.yaml
+++ b/kubernetes/apps/networking/external-dns/cloudflare/rbac.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: external-dns-cloudflare
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/kubernetes/apps/networking/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/unifi/helmrelease.yaml
@@ -93,7 +93,7 @@ spec:
         serviceAccount:
           name: *app
     defaultPodOptions:
-      hostUsers: false
+      automountServiceAccountToken: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/networking/external-dns/unifi/rbac.yaml
+++ b/kubernetes/apps/networking/external-dns/unifi/rbac.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: external-dns-unifi
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
## Summary

- app-template 5.0.0 defaults `automountServiceAccountToken` to `false`, causing external-dns pods to crash with `no such file or directory` on the SA token path
- The `ServiceAccount` was dual-owned by both Helm (via `serviceAccount.name` in the app-template chart) and Kustomize (via `rbac.yaml`), causing it to disappear during Helm rollbacks and leaving pods unable to start
- Removes `ServiceAccount` from `rbac.yaml` for both cloudflare and unifi — SA is now exclusively managed by app-template
- Adds `automountServiceAccountToken: true` to `defaultPodOptions` in both HelmReleases
- Removes `hostUsers: false` (not needed for external-dns)

Pattern matches [buroa/k8s-gitops](https://github.com/buroa/k8s-gitops/blob/main/kubernetes/apps/networking/external-dns/cloudflare/helmrelease.yaml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)