### PR TITLE
fix(gatus): add automountServiceAccountToken and fix SA ownership for app-template 5.0.0

### DIFF
--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -65,7 +65,7 @@ spec:
         serviceAccount:
           name: *app
     defaultPodOptions:
-      hostUsers: false
+      automountServiceAccountToken: true
     persistence:
       config:
         type: emptyDir

--- a/kubernetes/apps/observability/gatus/app/rbac.yaml
+++ b/kubernetes/apps/observability/gatus/app/rbac.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gatus
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
## Summary

Same issue as #1614 (external-dns): app-template 5.0.0 defaults `automountServiceAccountToken` to `false`, breaking the `gatus-sidecar` init container's in-cluster Kubernetes config access.

- Removes `ServiceAccount` from `rbac.yaml` — SA is now exclusively owned by app-template
- Replaces `hostUsers: false` with `automountServiceAccountToken: true` in `defaultPodOptions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)