### PR TITLE
feat(observability): move kubernetes platform dashboards to kube-prometheus-stack

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/instance/kustomization.yaml
@@ -5,5 +5,4 @@ resources:
   - ./externalsecret.yaml
   - ./grafana.yaml
   - ./grafanadatasource.yaml
-  - ./grafanadashboard.yaml
   - ./servicemonitor.yaml

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/grafanadashboard.yaml
@@ -53,7 +53,7 @@ spec:
   datasources:
     - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
-  url: https://grafana.com/api/dashboards/15758/revisions/42/download
+  url: https://grafana.com/api/dashboards/15758/revisions/46/download
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
@@ -67,7 +67,7 @@ spec:
   datasources:
     - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
-  url: https://grafana.com/api/dashboards/15759/revisions/35/download
+  url: https://grafana.com/api/dashboards/15759/revisions/40/download
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
@@ -81,7 +81,7 @@ spec:
   datasources:
     - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
-  url: https://grafana.com/api/dashboards/15760/revisions/38/download
+  url: https://grafana.com/api/dashboards/15760/revisions/39/download
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
@@ -100,7 +100,7 @@ spec:
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  name: node-exporter
+  name: node-exporter-full
 spec:
   allowCrossNamespaceImport: true
   instanceSelector:
@@ -109,7 +109,7 @@ spec:
   datasources:
     - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
-  url: https://grafana.com/api/dashboards/1860/revisions/41/download
+  url: https://grafana.com/api/dashboards/1860/revisions/45/download
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
@@ -123,7 +123,7 @@ spec:
   datasources:
     - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
-  url: https://grafana.com/api/dashboards/3662/revisions/2/download
+  url: https://grafana.com/api/dashboards/19105/revisions/9/download
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 resources:
   - ./alertmanagerconfig.yaml
   - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./prometheusrule.yaml


### PR DESCRIPTION
## Summary
Phase 2 of grafana-operator migration. Move the 10 platform-level dashboards from `grafana/instance/` into `kube-prometheus-stack/app/` to follow the per-app dashboard pattern.

Dashboards moved: kubernetes-api-server, kubernetes-coredns, kubernetes-global, kubernetes-namespaces, kubernetes-nodes, kubernetes-pods, kubernetes-volumes, node-exporter-full, prometheus, alertmanager.

Also bumped a few revision pins to match the user's pre-migration helmrelease (e.g. namespaces r46, nodes r40, pods r39).

## Test plan
- [ ] flux-local CI passes
- [ ] After merge: `kubectl -n observability get grafanadashboards` should still show all 10
- [ ] Spot-check 1-2 dashboards still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)