### PR TITLE
feat(observability): add storage dashboards (ceph, volsync)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/grafanadashboard.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/grafanadashboard.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: ceph-cluster
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/2842/revisions/18/download
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: ceph-osd
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/5336/revisions/9/download
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: ceph-pools
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/5342/revisions/9/download

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/volsync-system/volsync/app/grafanadashboard.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/grafanadashboard.yaml
@@ -1,5 +1,4 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -8,9 +7,9 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
-    - datasourceName: prometheus
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   envs:
     - name: VAR_REPLICATIONDESTNAME

--- a/kubernetes/apps/volsync-system/volsync/app/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/kustomization.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-#  - ./grafanadashboard.yaml
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./mutatingadmissionpolicy.yaml


### PR DESCRIPTION
## Summary
Phase 2 of grafana-operator migration. Add per-app GrafanaDashboard CRs:
- `rook-ceph`: ceph-cluster (2842), ceph-osd (5336), ceph-pools (5342)
- `volsync`: volsync (21356) - using existing scaffold; updated label to `dashboards: grafana`

## Test plan
- [ ] flux-local CI passes
- [ ] After merge: dashboards appear in Grafana UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)