### PR TITLE
feat(observability): add cluster infra dashboards

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/grafanadashboard.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/grafanadashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cert-manager
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/20842/revisions/3/download

--- a/kubernetes/apps/cert-manager/cert-manager/app/kustomization.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/external-secrets/external-secrets/app/grafanadashboard.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/grafanadashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: external-secrets
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_METRICS
+  url: https://grafana.com/api/dashboards/21640/revisions/4/download

--- a/kubernetes/apps/external-secrets/external-secrets/app/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/kustomization.yaml
@@ -2,4 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/flux-system/flux-instance/app/grafanadashboard.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/grafanadashboard.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: flux-cluster
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/refs/heads/main/monitoring/configs/dashboards/cluster.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: flux-control-plane
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/refs/heads/main/monitoring/configs/dashboards/control-plane.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: flux-logs
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/refs/heads/main/monitoring/configs/dashboards/logs.json

--- a/kubernetes/apps/flux-system/flux-instance/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./receiver
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/kube-system/spegel/app/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/grafanadashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: spegel
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  url: https://raw.githubusercontent.com/spegel-org/spegel/v0.7.0/charts/spegel/monitoring/grafana-dashboard.json

--- a/kubernetes/apps/kube-system/spegel/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/kustomization.yaml
@@ -2,4 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary
Phase 2 of grafana-operator migration. Add per-app GrafanaDashboard CRs:
- `cert-manager` (20842)
- `external-secrets` (21640) - uses DS_METRICS input
- `flux-instance` - 3 dashboards from fluxcd/flux2-monitoring-example
- `spegel` - dashboard from spegel-org repo

## Test plan
- [ ] flux-local CI passes
- [ ] After merge: dashboards appear in Grafana UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)