### PR TITLE
feat(observability): add networking dashboards

### DIFF
--- a/kubernetes/apps/networking/cloudflared/app/grafanadashboard.yaml
+++ b/kubernetes/apps/networking/cloudflared/app/grafanadashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cloudflared
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/17457/revisions/6/download

--- a/kubernetes/apps/networking/cloudflared/app/kustomization.yaml
+++ b/kubernetes/apps/networking/cloudflared/app/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml
 configMapGenerator:
   - name: cloudflared-configmap

--- a/kubernetes/apps/networking/envoy-gateway/app/grafanadashboard.yaml
+++ b/kubernetes/apps/networking/envoy-gateway/app/grafanadashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: envoy
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_AFRANET_PROMETHEUS
+  url: https://grafana.com/api/dashboards/23239/revisions/1/download

--- a/kubernetes/apps/networking/envoy-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/networking/envoy-gateway/app/kustomization.yaml
@@ -2,4 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/networking/external-dns/cloudflare/grafanadashboard.yaml
+++ b/kubernetes/apps/networking/external-dns/cloudflare/grafanadashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: external-dns
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/15038/revisions/3/download

--- a/kubernetes/apps/networking/external-dns/cloudflare/kustomization.yaml
+++ b/kubernetes/apps/networking/external-dns/cloudflare/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./prometheusrule.yaml
   - ./rbac.yaml

--- a/kubernetes/apps/networking/tailscale-operator/app/grafanadashboard.yaml
+++ b/kubernetes/apps/networking/tailscale-operator/app/grafanadashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: tailscale
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/24178/revisions/4/download

--- a/kubernetes/apps/networking/tailscale-operator/app/kustomization.yaml
+++ b/kubernetes/apps/networking/tailscale-operator/app/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary
Phase 2 of grafana-operator migration. Add per-app GrafanaDashboard CRs:
- `cloudflared` (17457)
- `envoy-gateway` (23239) - using DS_AFRANET_PROMETHEUS input mapping
- `external-dns` (15038) - placed under cloudflare/ instance
- `tailscale-operator` (24178)

## Test plan
- [ ] flux-local CI passes
- [ ] After merge: dashboards appear in Grafana UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)