### PR TITLE
fix(grafana): drop VOLSYNC_PUID/PGID overrides causing NFS perm errors

### DIFF
--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -44,8 +44,6 @@ spec:
     substitute:
       APP: *app2
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_PUID: "472"
-      VOLSYNC_PGID: "472"
   prune: true
   retryInterval: 2m
   sourceRef:


### PR DESCRIPTION
## Summary

The Grafana PVC has been stuck \`Pending\` since the operator migration merged. Volsync ReplicationDestination pods are crashing with:

\`\`\`
unable to read format blob: error determining sharded path:
error getting sharding parameters for storage:
unable to complete GetBlobFromPath:/repository/.shards despite 10 retries:
open /repository/.shards: permission denied
\`\`\`

### Root cause
The kopia repository on the NFS share (\`mars.internal:/mnt/sharecache/VolsyncKopia\`) has files owned by UID 1000 - the volsync default. I had set \`VOLSYNC_PUID: "472"\` / \`VOLSYNC_PGID: "472"\` to match Grafana's container UID, which made the mover unable to read the existing repository contents.

### Fix
Drop the UID overrides. Mover runs as 1000:1000 (matching NFS), Grafana runs as 472:472 inside the pod, and \`fsGroup: 472\` with \`fsGroupChangePolicy: OnRootMismatch\` handles the chown at mount time so Grafana can write to its PVC.

## Test plan
- [ ] Merge → wait for Flux reconcile
- [ ] \`kubectl -n observability get replicationdestination grafana-dst\` shows successful sync (or empty - no prior backup yet, that's fine)
- [ ] \`kubectl -n observability get pvc grafana\` reaches \`Bound\`
- [ ] Grafana pod starts and serves https://grafana.pipitonelabs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)