### PR TITLE
feat(database): add CloudNativePG grafana dashboard

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/app/grafanadashboard.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/grafanadashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cloudnative-pg
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  url: https://raw.githubusercontent.com/cloudnative-pg/grafana-dashboards/main/charts/cluster/grafana-dashboard.json

--- a/kubernetes/apps/database/cloudnative-pg/app/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary
Add the official CloudNativePG cluster dashboard from \`cloudnative-pg/grafana-dashboards\`. Provides PostgreSQL/CNPG cluster metrics: replication lag, WAL stats, connections, transaction rates, and more.

## Test plan
- [ ] flux-local CI passes
- [ ] After merge: dashboard \"CloudNativePG\" appears in the Grafana UI under the \`database\` folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)