### PR TITLE
fix(gatus): override authentik health check to use ready endpoint

### DIFF
--- a/kubernetes/apps/security/authentik/app/httproute.yaml
+++ b/kubernetes/apps/security/authentik/app/httproute.yaml
@@ -5,6 +5,11 @@ kind: HTTPRoute
 metadata:
   name: authentik
   namespace: security
+  annotations:
+    gatus.home-operations.com/endpoint: |-
+      url: https://sso.pipitonelabs.com/-/health/ready/
+      conditions:
+        - "[STATUS] == 204"
 spec:
   hostnames: ["sso.pipitonelabs.com"]
   parentRefs:


### PR DESCRIPTION
## Summary
- The gatus-sidecar auto-generated an HTTP check for the authentik HTTPRoute against the root URL (`https://sso.pipitonelabs.com`), which returns a 302 redirect to the login page
- This caused Alertmanager to fire `GatusEndpointDown` for authentik even though all pods are healthy
- Added `gatus.home-operations.com/endpoint` annotation to override the check with `/-/health/ready/` which returns 204 when authentik is healthy

## Test plan
- [ ] Flux syncs the updated HTTPRoute
- [ ] Gatus-sidecar picks up the new annotation and updates the endpoint
- [ ] Gatus shows authentik as UP
- [ ] `GatusEndpointDown` alert clears in Alertmanager

🤖 Generated with [Claude Code](https://claude.com/claude-code)