### PR TITLE
revert: remove gatus health check override for authentik

### DIFF
--- a/kubernetes/apps/security/authentik/app/httproute.yaml
+++ b/kubernetes/apps/security/authentik/app/httproute.yaml
@@ -5,11 +5,6 @@ kind: HTTPRoute
 metadata:
   name: authentik
   namespace: security
-  annotations:
-    gatus.home-operations.com/endpoint: |-
-      url: https://sso.pipitonelabs.com/-/health/ready/
-      conditions:
-        - "[STATUS] == 204"
 spec:
   hostnames: ["sso.pipitonelabs.com"]
   parentRefs:


### PR DESCRIPTION
Reverts #1674.

The `gatus.home-operations.com/endpoint` annotation override was incorrect — the pre-existing auto-generated check was working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)