### PR TITLE
fix(gatus): raise sidecar memory limit to 128Mi to stop OOMKill

### DIFF
--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
               requests:
                 cpu: 10m
               limits:
-                memory: 32Mi
+                memory: 128Mi
             restartPolicy: Always
         containers:
           app:


### PR DESCRIPTION
## Problem

The `gatus-sidecar` (native sidecar / init container with `restartPolicy: Always`) was capped at **32Mi** memory. The Renovate bump `0.0.15 → 0.0.18` (#cf2d453b area, commit 4c637f7d) pushed its startup memory past that limit, so it was **OOMKilled (exit 137) on every start** — 84 restarts over ~6.5h.

Effects:
- Pod stuck at `1/2` Ready (app ran fine; sidecar dead).
- Deployment reported 0/1 available → **`KubeDeploymentReplicasMismatch`** alert firing to Pushover.

## Diagnosis

Measured live: the sidecar idles at **34Mi** — already above the old 32Mi limit, before Go's heap spikes during the initial HTTPRoute informer sync.

## Fix

Raise the sidecar memory limit `32Mi → 128Mi` (comfortable headroom; trivial cost). After the change the pod runs `2/2` with 0 restarts and the deployment is `1/1` available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)