### PR TITLE
fix(intel-gpu): disable xpumd health monitoring to stop CrashLoopBackOff

### DIFF
--- a/kubernetes/apps/kube-system/intel-gpu-resource-driver/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/intel-gpu-resource-driver/app/helmrelease.yaml
@@ -22,6 +22,13 @@ spec:
     name: intel-gpu-resource-driver
   interval: 1h
   values:
+    kubeletPlugin:
+      # xpumd (Intel XPU Manager) is not deployed, so health monitoring (-m)
+      # cannot reach /run/xpumd/intelxpuinfo.sock and panics the plugin.
+      # Disable it and let the driver read device details directly (requires privileged).
+      privileged: true
+      healthMonitoring:
+        enabled: false
     cdi:
       staticPath: /var/cdi/static
       dynamicPath: /var/cdi/dynamic


### PR DESCRIPTION
## Problem

The `intel-gpu-resource-driver-kubelet-plugin` pods were in CrashLoopBackOff (846 restarts over 4 days).

The v0.10.x chart defaults `kubeletPlugin.healthMonitoring.enabled: true`, which passes the `-m` flag to the kubelet plugin. That flag makes it connect to **xpumd (Intel XPU Manager)** at `/run/xpumd/intelxpuinfo.sock` — a daemon that is not deployed in this cluster. After a connection timeout the health-monitoring goroutine panics and takes down the whole process:

```
E xpumd-client: error calling WatchDeviceHealth ... dial unix /run/xpumd/intelxpuinfo.sock: connect: no such file or directory
panic: xpumd-client: failed to connect to xpumd within expected time, exiting
```

GPU device publishing itself was working fine (`Publishing resources len=1`, `devices: 1`). The crash was purely the optional health monitor. This started with the 0.9.1 → 0.10.0 upgrade (#220b0d5b, 2026-04-17), which introduced this feature.

## Fix

- Set `kubeletPlugin.healthMonitoring.enabled: false` (removes the `-m` flag, no xpumd needed).
- Set `kubeletPlugin.privileged: true` so the driver reads device details directly from the hardware (per the chart's own guidance when health monitoring is disabled).

Verified by rendering the chart with the new values: the DaemonSet args drop to just `--healthcheck-port=51516`, and the security context gets `privileged: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)