### PR TITLE
feat(database): add dedicated tradeforge-pg cnpg cluster

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/externalsecret-tradeforge.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/externalsecret-tradeforge.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Password for the PostgREST login role (authenticator), consumed by
+# Cluster.spec.managed.roles. Sourced from the shared `cloudnative-pg` 1Password
+# item, same as every other app's <app>_postgres_* credentials.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tradeforge-pg-authenticator
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: tradeforge-pg-authenticator
+    template:
+      type: kubernetes.io/basic-auth
+      data:
+        username: "{{ .tradeforge_authenticator_username }}"
+        password: "{{ .tradeforge_authenticator_password }}"
+  dataFrom:
+    - extract:
+        key: cloudnative-pg
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Password for the Realtime login role (tradeforge_realtime), consumed by
+# Cluster.spec.managed.roles.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tradeforge-pg-realtime
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: tradeforge-pg-realtime
+    template:
+      type: kubernetes.io/basic-auth
+      data:
+        username: "{{ .tradeforge_realtime_username }}"
+        password: "{{ .tradeforge_realtime_password }}"
+  dataFrom:
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
@@ -3,8 +3,21 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cluster17.yaml
+  - ./externalsecret-tradeforge.yaml
   - ./objectstore-outline.yaml
   - ./objectstore-postgres17.yaml
+  - ./objectstore-tradeforge.yaml
   - ./outline.yaml
   - ./prometheusrule.yaml
   - ./scheduledbackup.yaml
+  - ./tradeforge.yaml
+configMapGenerator:
+  - name: tradeforge-bootstrap-sql
+    files:
+      - ./sql/00-supabase-compat.sql
+      - ./sql/0001_initial_schema.sql
+      - ./sql/0002_harden_rls_drop_public_read.sql
+      - ./sql/0003_reporter_rate_limit.sql
+      - ./sql/seed.sql
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/database/cloudnative-pg/cluster/objectstore-tradeforge.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/objectstore-tradeforge.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/barmancloud.cnpg.io/objectstore_v1.json
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: garage-s3-tradeforge
+spec:
+  configuration:
+    data:
+      compression: bzip2
+    destinationPath: s3://tradeforge-pg/
+    endpointURL: https://s3.pipitonelabs.com
+    s3Credentials:
+      accessKeyId:
+        name: cloudnative-pg-secret
+        key: garage-aws-access-key-id
+      secretAccessKey:
+        name: cloudnative-pg-secret
+        key: garage-aws-secret-access-key
+    wal:
+      compression: bzip2
+      maxParallel: 4
+  retentionPolicy: 30d

--- a/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -31,3 +31,20 @@ spec:
   method: plugin
   pluginConfiguration:
     name: barman-cloud.cloudnative-pg.io
+
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: tradeforge-pg
+spec:
+  schedule: "@daily"
+  immediate: true
+  backupOwnerReference: self
+  cluster:
+    name: tradeforge-pg
+
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/database/cloudnative-pg/cluster/sql/00-supabase-compat.sql
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/sql/00-supabase-compat.sql
@@ -1,0 +1,76 @@
+-- ============================================================================
+-- Supabase-compat shim for self-hosted PostgREST + Realtime
+-- ============================================================================
+-- TradeForge's schema (0001) was written for Supabase, whose platform provides
+-- the `auth` schema, `auth.jwt()`, the anon/authenticated/service_role roles, an
+-- `extensions` schema, and the `supabase_realtime` publication. A bare
+-- CloudNativePG + PostgREST stack has none of these, so RLS (40+ policies that
+-- read `auth.jwt() ->> 'sub'`) and the table GRANTs in 0001 would fail.
+--
+-- This file recreates exactly those primitives. It runs FIRST (before 0001) via
+-- the cluster's bootstrap.initdb.postInitApplicationSQLRefs, as superuser in the
+-- `tradeforge` database. It is idempotent.
+-- ============================================================================
+
+-- Schemas the app schema expects to already exist ---------------------------
+CREATE SCHEMA IF NOT EXISTS extensions;   -- 0001 installs uuid-ossp/pgcrypto here
+CREATE SCHEMA IF NOT EXISTS auth;
+
+-- auth.jwt()/uid()/role(): resolve the per-request claims PostgREST injects ---
+CREATE OR REPLACE FUNCTION auth.jwt() RETURNS jsonb LANGUAGE sql STABLE AS $$
+  SELECT coalesce(current_setting('request.jwt.claims', true), '{}')::jsonb;
+$$;
+CREATE OR REPLACE FUNCTION auth.uid() RETURNS text LANGUAGE sql STABLE AS $$
+  SELECT auth.jwt() ->> 'sub';
+$$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $$
+  SELECT auth.jwt() ->> 'role';
+$$;
+
+-- Supabase roles -------------------------------------------------------------
+-- anon/authenticated/service_role are NOLOGIN. PostgREST logs in as
+-- `authenticator` and SET ROLEs to one of them based on the JWT `role` claim.
+-- `authenticator` MUST stay NOINHERIT and must NOT own any table, otherwise it
+-- would bypass RLS. It is created NOLOGIN here; CNPG managed.roles adopts it and
+-- adds LOGIN + the password from the tradeforge-pg-authenticator secret.
+-- `tradeforge_realtime` is the Realtime login role (managed.roles adds LOGIN+pw).
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+    CREATE ROLE anon NOLOGIN NOINHERIT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    CREATE ROLE authenticated NOLOGIN NOINHERIT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    CREATE ROLE service_role NOLOGIN NOINHERIT BYPASSRLS;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticator') THEN
+    CREATE ROLE authenticator NOLOGIN NOINHERIT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'tradeforge_realtime') THEN
+    CREATE ROLE tradeforge_realtime NOLOGIN REPLICATION;
+  END IF;
+END $$;
+
+GRANT anon, authenticated, service_role TO authenticator;
+
+-- Schema usage + default privileges for the API roles ------------------------
+-- (Table-level GRANTs are in 0001; these cover schema usage and the sequences
+-- 0001 creates afterward, so INSERTs on serial/identity columns work.)
+GRANT USAGE ON SCHEMA public     TO anon, authenticated, service_role;
+GRANT USAGE ON SCHEMA extensions TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO anon, authenticated, service_role;
+
+-- Realtime needs to create its _realtime schema + a logical replication slot --
+GRANT ALL ON DATABASE tradeforge TO tradeforge_realtime;
+GRANT ALL ON SCHEMA public TO tradeforge_realtime;
+
+-- Empty publication that 0001 ALTERs ... ADD TABLE into ----------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime') THEN
+    CREATE PUBLICATION supabase_realtime;
+  END IF;
+END $$;

--- a/kubernetes/apps/database/cloudnative-pg/cluster/sql/0001_initial_schema.sql
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/sql/0001_initial_schema.sql
@@ -1,0 +1,402 @@
+-- ============================================================================
+-- TradeForge — consolidated database schema
+-- ============================================================================
+-- This single file creates the COMPLETE TradeForge schema on a fresh Supabase
+-- project. It is the authoritative, verified consolidation of the original
+-- incremental migrations PLUS the objects that had been applied directly to the
+-- production database. Run this ONCE on a new project, then run `seed.sql`.
+--
+-- How to apply (pick one):
+--   A) Supabase Dashboard → SQL Editor → paste this whole file → Run.
+--      Then do the same with seed.sql.
+--   B) Supabase CLI:  supabase db push   (this file is also mirrored to
+--      supabase/migrations/0001_initial_schema.sql), then run seed.sql.
+--
+-- Auth model: this app authenticates with CLERK, not Supabase Auth. The Clerk
+-- session JWT is forwarded to Supabase (see src/services/supabase.ts) via the
+-- native "Third-Party Auth" integration, so RLS resolves the current user with
+-- `auth.jwt() ->> 'sub'` (the Clerk user id). You MUST enable the Clerk
+-- third-party auth integration in the Supabase dashboard for RLS to work — see
+-- SETUP-INSTRUCTIONS.html.
+--
+-- The script is idempotent: it can be re-run safely.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- Extensions
+-- ----------------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA extensions;  -- uuid_generate_v4()
+CREATE EXTENSION IF NOT EXISTS pgcrypto    WITH SCHEMA extensions;  -- gen_random_uuid()
+
+-- ============================================================================
+-- TABLES
+-- ============================================================================
+
+-- profiles: one row per Clerk user. `id` is the Clerk user id (e.g. user_xxx).
+CREATE TABLE IF NOT EXISTS public.profiles (
+    id         text PRIMARY KEY,
+    email      text NOT NULL,
+    full_name  text,
+    avatar_url text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- prop_firms: catalog of prop-firm rule templates (seeded by seed.sql).
+CREATE TABLE IF NOT EXISTS public.prop_firms (
+    id                 uuid PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
+    name               text NOT NULL UNIQUE,
+    daily_drawdown_pct numeric(5,2) NOT NULL,
+    max_drawdown_pct   numeric(5,2) NOT NULL,
+    profit_target_pct  numeric(5,2) NOT NULL,
+    rules_description  text,
+    created_at         timestamptz NOT NULL DEFAULT now()
+);
+
+-- accounts: a user's trading accounts, each tied to a prop firm.
+CREATE TABLE IF NOT EXISTS public.accounts (
+    id                            uuid PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
+    user_id                       text NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    prop_firm_id                  uuid NOT NULL REFERENCES public.prop_firms(id),
+    name                          text NOT NULL,
+    starting_balance              numeric(12,2) NOT NULL,
+    current_balance               numeric(12,2) NOT NULL DEFAULT 0,
+    status                        text NOT NULL DEFAULT 'active'
+                                    CHECK (status = ANY (ARRAY['active','inactive','blown'])),
+    created_at                    timestamptz NOT NULL DEFAULT now(),
+    updated_at                    timestamptz NOT NULL DEFAULT now(),
+    one_r_value                   numeric,
+    custom_daily_drawdown_pct     numeric,
+    custom_max_drawdown_pct       numeric,
+    custom_profit_target_pct      numeric,
+    custom_daily_drawdown_dollars numeric,
+    custom_max_drawdown_dollars   numeric,
+    custom_profit_target_dollars  numeric
+);
+COMMENT ON COLUMN public.accounts.one_r_value IS
+    'Standard risk amount (1R) per trade in dollars for R-multiple calculations';
+
+-- trades: individual trade records (CSV-imported or manual).
+CREATE TABLE IF NOT EXISTS public.trades (
+    id          uuid PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
+    account_id  uuid NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+    symbol      text NOT NULL,
+    side        text NOT NULL CHECK (side = ANY (ARRAY['long','short'])),
+    quantity    numeric(12,4) NOT NULL,
+    entry_price numeric(12,4) NOT NULL,
+    exit_price  numeric(12,4),
+    entry_time  timestamptz NOT NULL,
+    exit_time   timestamptz,
+    pnl         numeric(12,2),
+    fees        numeric(12,2) DEFAULT 0,
+    notes       text,
+    created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- account_performance: imported Rithmic performance summaries per account.
+CREATE TABLE IF NOT EXISTS public.account_performance (
+    id                  uuid PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
+    account_id          uuid NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+    source_account_name text NOT NULL,
+    trade_pnl           numeric(12,2) NOT NULL DEFAULT 0,
+    commission_fees     numeric(12,2) NOT NULL DEFAULT 0,
+    net_pnl             numeric(12,2) NOT NULL DEFAULT 0,
+    trade_count         integer NOT NULL DEFAULT 0,
+    winning_trades      integer NOT NULL DEFAULT 0,
+    losing_trades       integer NOT NULL DEFAULT 0,
+    win_pct             numeric(5,2) NOT NULL DEFAULT 0,
+    lose_pct            numeric(5,2) NOT NULL DEFAULT 0,
+    scratched_trades    integer NOT NULL DEFAULT 0,
+    scratched_pct       numeric(5,2) NOT NULL DEFAULT 0,
+    ticks_made          integer NOT NULL DEFAULT 0,
+    max_drawdown        numeric(12,2),
+    max_drawdown_pct    numeric(5,2),
+    imported_at         timestamptz NOT NULL DEFAULT now(),
+    created_at          timestamptz NOT NULL DEFAULT now()
+);
+COMMENT ON TABLE public.account_performance IS
+    'Stores imported Rithmic performance summary data linked to TradeForge accounts';
+
+-- prop_firm_payouts: payout-rule templates per prop firm (seeded by seed.sql).
+CREATE TABLE IF NOT EXISTS public.prop_firm_payouts (
+    id                     uuid PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
+    prop_firm_id           uuid NOT NULL REFERENCES public.prop_firms(id) ON DELETE CASCADE,
+    default_profit_split   numeric(5,2) NOT NULL,
+    max_profit_split       numeric(5,2),
+    profit_split_type      text DEFAULT 'fixed',
+    first_payout_wait_days integer,
+    payout_frequency_days  integer,
+    payout_window_start    integer,
+    payout_window_end      integer,
+    minimum_payout         numeric(10,2),
+    maximum_payout         numeric(10,2),
+    min_trading_days       integer,
+    min_winning_days       integer,
+    winning_day_threshold  numeric(10,2),
+    consistency_rule_pct   numeric(5,2),
+    processing_days        integer,
+    payment_methods        text[],
+    is_active              boolean DEFAULT true,
+    notes                  text,
+    created_at             timestamptz NOT NULL DEFAULT now(),
+    updated_at             timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS prop_firm_payouts_firm_unique
+    ON public.prop_firm_payouts(prop_firm_id);
+
+-- ticino_trades: per-user live trade feed posted by the Sierra Chart reporter
+-- (via the ticino-reporter edge function). `user_id` is stamped server-side.
+CREATE TABLE IF NOT EXISTS public.ticino_trades (
+    id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    trade_id           text NOT NULL UNIQUE,
+    instrument         text NOT NULL,
+    side               text NOT NULL CHECK (side = ANY (ARRAY['LONG','SHORT'])),
+    entry_time         timestamptz NOT NULL,
+    exit_time          timestamptz NOT NULL,
+    entry_price        numeric(12,4) NOT NULL,
+    exit_price         numeric(12,4) NOT NULL,
+    stop_price         numeric(12,4) NOT NULL,
+    qty                integer NOT NULL,
+    r_multiple         numeric(8,4) NOT NULL,
+    duration_minutes   integer NOT NULL,
+    exit_reason        text NOT NULL CHECK (exit_reason = ANY (ARRAY['target','stop','be','manual'])),
+    session            text NOT NULL CHECK (session = ANY (ARRAY['rth','globex','other'])),
+    is_replay          boolean NOT NULL DEFAULT false,
+    is_sim             boolean NOT NULL DEFAULT false,
+    user_id            text NOT NULL REFERENCES public.profiles(id),
+    entry_mml_level    text,
+    exit_mml_level     text,
+    t1_hit             boolean,
+    t2_hit             boolean,
+    t3_hit             boolean,
+    exit_reason_detail text,
+    initial_stop_price numeric(12,4),
+    final_stop_price   numeric(12,4),
+    weighted_r         numeric(8,4),
+    created_at         timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_ticino_trades_entry_time
+    ON public.ticino_trades(entry_time DESC);
+CREATE INDEX IF NOT EXISTS idx_ticino_trades_live_entry_time
+    ON public.ticino_trades(entry_time DESC) WHERE is_replay = false;
+CREATE INDEX IF NOT EXISTS idx_ticino_trades_user_id_entry_time
+    ON public.ticino_trades(user_id, entry_time DESC);
+
+-- ticino_user_secrets: maps a per-user shared secret to a user_id. The reporter
+-- sends X-Trade-Secret; the edge function looks up the owner here (service role).
+CREATE TABLE IF NOT EXISTS public.ticino_user_secrets (
+    user_id      text PRIMARY KEY REFERENCES public.profiles(id) ON DELETE CASCADE,
+    trade_secret text NOT NULL UNIQUE,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+-- ticino_session_configs: per-user Ticino algo settings, upserted by the edge
+-- function once per session so the dashboard can show active configuration.
+CREATE TABLE IF NOT EXISTS public.ticino_session_configs (
+    id                     uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id                text NOT NULL,
+    session_id             text NOT NULL,
+    session_start          timestamptz NOT NULL,
+    instrument             text NOT NULL,
+    mode                   text NOT NULL CHECK (mode = ANY (ARRAY['LIVE','SIM','REPLAY'])),
+    ticino_version         text,
+    t1_contracts           integer,
+    t1_r                   integer,
+    t1_points              numeric(10,4),
+    t2_contracts           integer,
+    t2_r                   integer,
+    t2_points              numeric(10,4),
+    t3_contracts           integer,
+    t3_r                   integer,
+    t3_points              numeric(10,4),
+    stop_mode              integer,
+    enable_internal_trail  boolean,
+    min_close_strength_pct integer,
+    require_green_close     boolean,
+    require_red_close       boolean,
+    max_queue_size         integer,
+    pause1_from            integer,
+    created_at             timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (user_id, session_id)
+);
+CREATE INDEX IF NOT EXISTS idx_ticino_session_configs_user_recent
+    ON public.ticino_session_configs(user_id, instrument, mode, session_start DESC);
+
+-- ============================================================================
+-- FUNCTIONS + TRIGGERS (updated_at maintenance)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.update_prop_firm_payouts_updated_at()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $fn$
+BEGIN NEW.updated_at = now(); RETURN NEW; END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.set_ticino_user_secrets_updated_at()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+BEGIN NEW.updated_at = now(); RETURN NEW; END;
+$fn$;
+REVOKE EXECUTE ON FUNCTION public.set_ticino_user_secrets_updated_at()
+    FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS prop_firm_payouts_updated_at ON public.prop_firm_payouts;
+CREATE TRIGGER prop_firm_payouts_updated_at
+    BEFORE UPDATE ON public.prop_firm_payouts
+    FOR EACH ROW EXECUTE FUNCTION public.update_prop_firm_payouts_updated_at();
+
+DROP TRIGGER IF EXISTS ticino_user_secrets_set_updated_at ON public.ticino_user_secrets;
+CREATE TRIGGER ticino_user_secrets_set_updated_at
+    BEFORE UPDATE ON public.ticino_user_secrets
+    FOR EACH ROW EXECUTE FUNCTION public.set_ticino_user_secrets_updated_at();
+
+-- ============================================================================
+-- VIEWS (security_invoker = on → RLS of the querying user applies)
+-- ============================================================================
+CREATE OR REPLACE VIEW public.ticino_trade_stats_v WITH (security_invoker = on) AS
+ SELECT id,
+    (date_trunc('day', entry_time))::date AS trade_date,
+    instrument, user_id, side, qty, r_multiple, weighted_r, duration_minutes,
+    exit_reason, exit_reason_detail, t1_hit, t2_hit, t3_hit, session,
+    is_replay, is_sim, entry_mml_level, exit_mml_level, entry_time, exit_time
+   FROM public.ticino_trades;
+
+CREATE OR REPLACE VIEW public.ticino_session_configs_v WITH (security_invoker = on) AS
+ SELECT id, user_id, session_id, session_start, instrument, mode, ticino_version,
+    t1_contracts, t1_r, t1_points, t2_contracts, t2_r, t2_points,
+    t3_contracts, t3_r, t3_points, stop_mode, enable_internal_trail,
+    min_close_strength_pct, require_green_close, require_red_close,
+    max_queue_size, pause1_from, created_at
+   FROM public.ticino_session_configs;
+
+-- ============================================================================
+-- ROW LEVEL SECURITY
+-- All per-user policies scope rows to the Clerk user id from the forwarded JWT:
+--   (SELECT auth.jwt() ->> 'sub')
+-- ============================================================================
+ALTER TABLE public.profiles               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.prop_firms             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.accounts               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.trades                 ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.account_performance    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.prop_firm_payouts      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.ticino_trades          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.ticino_user_secrets    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.ticino_session_configs ENABLE ROW LEVEL SECURITY;
+
+-- profiles --------------------------------------------------------------------
+DROP POLICY IF EXISTS profiles_select_own ON public.profiles;
+CREATE POLICY profiles_select_own ON public.profiles FOR SELECT TO authenticated
+    USING (id = (SELECT auth.jwt() ->> 'sub'));
+DROP POLICY IF EXISTS profiles_insert_own ON public.profiles;
+CREATE POLICY profiles_insert_own ON public.profiles FOR INSERT TO authenticated
+    WITH CHECK (id = (SELECT auth.jwt() ->> 'sub'));
+DROP POLICY IF EXISTS profiles_update_own ON public.profiles;
+CREATE POLICY profiles_update_own ON public.profiles FOR UPDATE TO authenticated
+    USING (id = (SELECT auth.jwt() ->> 'sub')) WITH CHECK (id = (SELECT auth.jwt() ->> 'sub'));
+
+-- prop_firms (public reference data — readable by everyone) --------------------
+DROP POLICY IF EXISTS "Public can view prop firms" ON public.prop_firms;
+CREATE POLICY "Public can view prop firms" ON public.prop_firms FOR SELECT
+    TO anon, authenticated USING (true);
+
+-- accounts --------------------------------------------------------------------
+DROP POLICY IF EXISTS accounts_all_own ON public.accounts;
+CREATE POLICY accounts_all_own ON public.accounts FOR ALL TO authenticated
+    USING (user_id = (SELECT auth.jwt() ->> 'sub'))
+    WITH CHECK (user_id = (SELECT auth.jwt() ->> 'sub'));
+
+-- trades (scoped through the owning account) -----------------------------------
+DROP POLICY IF EXISTS trades_all_own ON public.trades;
+CREATE POLICY trades_all_own ON public.trades FOR ALL TO authenticated
+    USING (EXISTS (SELECT 1 FROM public.accounts
+                   WHERE accounts.id = trades.account_id
+                     AND accounts.user_id = (SELECT auth.jwt() ->> 'sub')))
+    WITH CHECK (EXISTS (SELECT 1 FROM public.accounts
+                        WHERE accounts.id = trades.account_id
+                          AND accounts.user_id = (SELECT auth.jwt() ->> 'sub')));
+
+-- account_performance (scoped through the owning account) ----------------------
+DROP POLICY IF EXISTS account_performance_all_own ON public.account_performance;
+CREATE POLICY account_performance_all_own ON public.account_performance FOR ALL TO authenticated
+    USING (EXISTS (SELECT 1 FROM public.accounts
+                   WHERE accounts.id = account_performance.account_id
+                     AND accounts.user_id = (SELECT auth.jwt() ->> 'sub')))
+    WITH CHECK (EXISTS (SELECT 1 FROM public.accounts
+                        WHERE accounts.id = account_performance.account_id
+                          AND accounts.user_id = (SELECT auth.jwt() ->> 'sub')));
+
+-- prop_firm_payouts (public reference data — readable by everyone) -------------
+DROP POLICY IF EXISTS prop_firm_payouts_read_all ON public.prop_firm_payouts;
+CREATE POLICY prop_firm_payouts_read_all ON public.prop_firm_payouts FOR SELECT
+    TO anon, authenticated USING (true);
+
+-- ticino_trades ---------------------------------------------------------------
+DROP POLICY IF EXISTS ticino_trades_all_own ON public.ticino_trades;
+CREATE POLICY ticino_trades_all_own ON public.ticino_trades FOR ALL TO authenticated
+    USING (user_id = (SELECT auth.jwt() ->> 'sub'))
+    WITH CHECK (user_id = (SELECT auth.jwt() ->> 'sub'));
+
+-- ticino_user_secrets ---------------------------------------------------------
+DROP POLICY IF EXISTS ticino_user_secrets_all_own ON public.ticino_user_secrets;
+CREATE POLICY ticino_user_secrets_all_own ON public.ticino_user_secrets FOR ALL TO authenticated
+    USING (user_id = (SELECT auth.jwt() ->> 'sub'))
+    WITH CHECK (user_id = (SELECT auth.jwt() ->> 'sub'));
+
+-- ticino_session_configs ------------------------------------------------------
+DROP POLICY IF EXISTS ticino_session_configs_all_own ON public.ticino_session_configs;
+CREATE POLICY ticino_session_configs_all_own ON public.ticino_session_configs FOR ALL TO authenticated
+    USING (user_id = (SELECT auth.jwt() ->> 'sub'))
+    WITH CHECK (user_id = (SELECT auth.jwt() ->> 'sub'));
+
+-- ============================================================================
+-- DATA API GRANTS
+-- PostgREST requires table-level GRANTs in addition to RLS policies. RLS still
+-- enforces row access; these grants only permit a role to attempt the operation.
+-- ============================================================================
+GRANT SELECT, INSERT, UPDATE         ON public.profiles            TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.profiles            TO service_role;
+GRANT SELECT                         ON public.prop_firms          TO anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.prop_firms          TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.accounts            TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.trades              TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.account_performance TO authenticated, service_role;
+GRANT SELECT                         ON public.prop_firm_payouts   TO anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.prop_firm_payouts   TO authenticated, service_role;
+GRANT SELECT                         ON public.ticino_trades       TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.ticino_trades       TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.ticino_user_secrets TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.ticino_session_configs TO authenticated, service_role;
+GRANT SELECT ON public.ticino_trade_stats_v       TO authenticated;
+GRANT SELECT ON public.ticino_session_configs_v   TO authenticated;
+
+-- ============================================================================
+-- REALTIME PUBLICATION
+-- The realtime stats dashboard subscribes to these tables. Membership is added
+-- idempotently (the supabase_realtime publication exists by default).
+-- ============================================================================
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_publication_tables
+                 WHERE pubname = 'supabase_realtime'
+                   AND schemaname = 'public' AND tablename = 'ticino_trades') THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.ticino_trades;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_publication_tables
+                 WHERE pubname = 'supabase_realtime'
+                   AND schemaname = 'public' AND tablename = 'ticino_session_configs') THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.ticino_session_configs;
+  END IF;
+END $$;
+
+-- ============================================================================
+-- STORAGE  (REMOVED for self-hosting)
+-- The upstream schema created a private 'csv-imports' bucket + per-user
+-- storage.objects policies. That depends on Supabase Storage's `storage` schema
+-- (storage.buckets / storage.objects / storage.foldername), which does NOT exist
+-- on a bare CloudNativePG + PostgREST stack and would fail this bootstrap.
+-- The app parses CSVs client-side and never uploads, so the block is omitted.
+-- If Storage is ever self-hosted, re-add it from tradeforge 0001 lines ~390-412.
+-- ============================================================================
+
+-- ============================================================================
+-- DONE. Next: run seed.sql to load the prop-firm catalog.
+-- ============================================================================

--- a/kubernetes/apps/database/cloudnative-pg/cluster/sql/0002_harden_rls_drop_public_read.sql
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/sql/0002_harden_rls_drop_public_read.sql
@@ -1,0 +1,20 @@
+-- ============================================================================
+-- Security hardening — drop world-readable RLS policies
+-- ============================================================================
+-- Three SELECT policies had been added ad hoc (via the Supabase dashboard) with
+-- USING (true) for the anon/public role. Because the anon key ships in the
+-- client bundle, these exposed every user's data to anyone:
+--   * ticino_trades            — all users' trade history
+--   * ticino_session_configs   — all users' bot/strategy settings
+-- and a redundant duplicate public-read on the prop_firms catalog table.
+--
+-- RLS policies are OR'd, so these permissive policies overrode the correct
+-- owner-scoped (*_all_own) policies. The owner-scoped policies remain in place;
+-- the Sierra Chart reporter writes via the service role (bypasses RLS) and the
+-- dashboard reads as the authenticated owner, so nothing legitimate relied on
+-- these. Idempotent and safe to re-run.
+-- ============================================================================
+
+DROP POLICY IF EXISTS "Public can read ticino_trades" ON public.ticino_trades;
+DROP POLICY IF EXISTS "Anon and auth can read ticino_session_configs" ON public.ticino_session_configs;
+DROP POLICY IF EXISTS "Allow anon read access to prop_firms" ON public.prop_firms;

--- a/kubernetes/apps/database/cloudnative-pg/cluster/sql/0003_reporter_rate_limit.sql
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/sql/0003_reporter_rate_limit.sql
@@ -1,0 +1,56 @@
+-- ============================================================================
+-- Rate limiting for the ticino-reporter edge function
+-- ============================================================================
+-- The reporter is a public endpoint authenticated by a per-user trade secret.
+-- This adds a fixed-window counter the edge function uses to limit ONLY failed
+-- authentication attempts (missing/invalid secret) per client IP, to blunt
+-- secret brute-forcing. Successful authenticated requests (real trades, sim,
+-- and replays) are never rate limited. The counter lives in Postgres (the edge
+-- function is stateless); only the service role touches it.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.ticino_reporter_rate_limit (
+  bucket_key    text        NOT NULL,
+  window_start  timestamptz NOT NULL,
+  request_count integer     NOT NULL DEFAULT 0,
+  PRIMARY KEY (bucket_key, window_start)
+);
+
+-- No policies → only the service role (which bypasses RLS) can read/write it.
+ALTER TABLE public.ticino_reporter_rate_limit ENABLE ROW LEVEL SECURITY;
+
+-- Atomic fixed-window check. Returns true if the request is within the limit,
+-- false if it should be rejected (HTTP 429). Increments the current window's
+-- counter and prunes the key's stale windows to keep the table bounded.
+CREATE OR REPLACE FUNCTION public.ticino_reporter_rate_check(
+  p_key            text,
+  p_limit          integer,
+  p_window_seconds integer
+) RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_window timestamptz := to_timestamp(
+    floor(extract(epoch FROM now()) / p_window_seconds) * p_window_seconds
+  );
+  v_count  integer;
+BEGIN
+  DELETE FROM public.ticino_reporter_rate_limit
+    WHERE bucket_key = p_key AND window_start < v_window;
+
+  INSERT INTO public.ticino_reporter_rate_limit AS r (bucket_key, window_start, request_count)
+  VALUES (p_key, v_window, 1)
+  ON CONFLICT (bucket_key, window_start)
+  DO UPDATE SET request_count = r.request_count + 1
+  RETURNING r.request_count INTO v_count;
+
+  RETURN v_count <= p_limit;
+END;
+$$;
+
+-- Lock the function down: clients (anon/authenticated) must never call it
+-- directly; only the edge function via the service role.
+REVOKE ALL ON FUNCTION public.ticino_reporter_rate_check(text, integer, integer) FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.ticino_reporter_rate_check(text, integer, integer) TO service_role;

--- a/kubernetes/apps/database/cloudnative-pg/cluster/sql/seed.sql
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/sql/seed.sql
@@ -1,0 +1,55 @@
+-- ============================================================================
+-- TradeForge — seed data (prop-firm catalog)
+-- ============================================================================
+-- Run AFTER schema.sql. Loads the shareable, non-personal reference data:
+--   * 10 prop-firm rule templates
+--   *  6 payout-rule templates (matched to firms by name, so no hard-coded ids)
+-- Idempotent: safe to re-run; existing rows are updated, not duplicated.
+-- Contains NO personal data (no users, accounts, or trades).
+-- ============================================================================
+
+-- prop_firms ------------------------------------------------------------------
+INSERT INTO public.prop_firms (name, daily_drawdown_pct, max_drawdown_pct, profit_target_pct, rules_description) VALUES
+  ('Apex Trader Funding', 2.50, 6.00, 6.00, 'Trailing drawdown from peak balance. No scaling required.'),
+  ('Topstep',             2.00, 4.50, 6.00, 'EOD trailing drawdown. Scaling plan available.'),
+  ('FTMO',                5.00,10.00,10.00, 'Balance-based drawdown. 30-day challenge period.'),
+  ('MyFundedFutures',     3.00, 5.00, 8.00, 'Trailing drawdown. Consistency rules apply.'),
+  ('Earn2Trade',          2.00, 4.00, 6.00, 'EOD drawdown calculation. Gauntlet Mini available.'),
+  ('TradeDay',            3.00, 6.00, 6.00, 'Real-time trailing drawdown. No time limit.'),
+  ('Rithmic',             2.50, 5.00, 6.00, 'Platform-specific rules. Used by multiple prop firms.'),
+  ('NinjaTrader',         2.00, 4.00, 5.00, 'Built-in risk management. Supports multiple brokers.'),
+  ('LucidTrading',        2.50, 5.50, 7.00, 'Progressive scaling program. Flexible withdrawal.'),
+  ('The Trading Pit',     4.00, 8.00, 8.00, 'Dynamic drawdown system. Multi-asset trading.')
+ON CONFLICT (name) DO UPDATE SET
+  daily_drawdown_pct = EXCLUDED.daily_drawdown_pct,
+  max_drawdown_pct   = EXCLUDED.max_drawdown_pct,
+  profit_target_pct  = EXCLUDED.profit_target_pct,
+  rules_description  = EXCLUDED.rules_description;
+
+-- prop_firm_payouts (keyed by firm name → resolves to the firm's generated id) -
+INSERT INTO public.prop_firm_payouts
+  (prop_firm_id, default_profit_split, max_profit_split, profit_split_type,
+   first_payout_wait_days, payout_frequency_days, payout_window_start, payout_window_end,
+   minimum_payout, maximum_payout, min_trading_days, min_winning_days,
+   winning_day_threshold, consistency_rule_pct, processing_days, payment_methods, is_active, notes)
+SELECT pf.id, v.default_profit_split, v.max_profit_split, v.profit_split_type,
+       v.first_payout_wait_days, v.payout_frequency_days, v.payout_window_start, v.payout_window_end,
+       v.minimum_payout, v.maximum_payout, v.min_trading_days, v.min_winning_days,
+       v.winning_day_threshold, v.consistency_rule_pct, v.processing_days, v.payment_methods, v.is_active, v.notes
+FROM (VALUES
+  ('Apex Trader Funding',100.00,90.00,'tiered',  8, 15,   1,   5, NULL::numeric,25000.00,NULL::int,NULL::int,NULL::numeric,30.00, 3, ARRAY['ACH','Wire','PayPal'],             true, '100% profit on first $25K, then 90%. Payout windows: 1st-5th and 15th-19th of each month.'),
+  ('Topstep',            100.00,90.00,'tiered',  NULL, 0, NULL,NULL, 125.00, NULL,    NULL,    5,       200.00,        NULL,  3, ARRAY['ACH','Wire','PayPal'],             true, '100% profit on first $10K, then 90%. Request payout after 5 winning days ($200+ profit each). No fixed schedule.'),
+  ('FTMO',                80.00,90.00,'scaling', 14, 0, NULL,NULL,  20.00, NULL,    4,       NULL,    NULL,          NULL,  2, ARRAY['Bank Transfer','Skrill','Crypto'], true, '80% base split, scaling to 90% for consistent traders. First payout after 14 days, then on-demand within 14-60 day cycle.'),
+  ('MyFundedFutures',     90.00,90.00,'fixed',    7, 14, NULL,NULL,  50.00, NULL,    NULL,    NULL,    NULL,          40.00, 3, ARRAY['ACH','Wire','PayPal'],             true, '90% profit split. Bi-weekly payouts after initial 7-day waiting period. 40% consistency rule.'),
+  ('Earn2Trade',          80.00,80.00,'fixed',   14, 14, NULL,NULL,  50.00, NULL,    NULL,    NULL,    NULL,          NULL,  5, ARRAY['ACH','Wire'],                      true, '80% profit split. Bi-weekly payouts after 14-day waiting period.'),
+  ('TradeDay',            90.00,90.00,'fixed',    7,  7, NULL,NULL, 100.00, NULL,    NULL,    NULL,    NULL,          NULL,  2, ARRAY['ACH','Wire','PayPal','Crypto'],    true, '90% profit split. Weekly payouts after 7-day waiting period.')
+) AS v(firm_name, default_profit_split, max_profit_split, profit_split_type,
+       first_payout_wait_days, payout_frequency_days, payout_window_start, payout_window_end,
+       minimum_payout, maximum_payout, min_trading_days, min_winning_days,
+       winning_day_threshold, consistency_rule_pct, processing_days, payment_methods, is_active, notes)
+JOIN public.prop_firms pf ON pf.name = v.firm_name
+ON CONFLICT (prop_firm_id) DO NOTHING;
+
+-- ============================================================================
+-- DONE.
+-- ============================================================================

--- a/kubernetes/apps/database/cloudnative-pg/cluster/tradeforge.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/tradeforge.yaml
@@ -1,0 +1,71 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: tradeforge-pg
+spec:
+  instances: 1 # dedicated cluster; bump to 2-3 later for HA
+  imageName: ghcr.io/cloudnative-pg/postgresql:17
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
+  storage:
+    size: 20Gi
+    storageClass: openebs-hostpath
+  # No superuserSecret: with enableSuperuserAccess CNPG auto-generates
+  # tradeforge-pg-superuser. `kubectl exec ... psql` connects via local socket.
+  enableSuperuserAccess: true
+  postgresql:
+    parameters:
+      max_connections: "200"
+      shared_buffers: 256MB
+      wal_level: logical # required for supabase/realtime logical replication
+      max_replication_slots: "10"
+      max_wal_senders: "10"
+      max_logical_replication_workers: "8"
+  managed:
+    roles:
+      - name: authenticator # PostgREST login role (created NOLOGIN by the shim)
+        ensure: present
+        login: true
+        superuser: false
+        passwordSecret:
+          name: tradeforge-pg-authenticator
+      - name: tradeforge_realtime # Realtime login role (created NOLOGIN by the shim)
+        ensure: present
+        login: true
+        replication: true
+        passwordSecret:
+          name: tradeforge-pg-realtime
+  bootstrap:
+    initdb:
+      database: tradeforge
+      owner: tradeforge # app owner role; PostgREST uses `authenticator`, not this
+      postInitApplicationSQLRefs:
+        configMapRefs:
+          - name: tradeforge-bootstrap-sql
+            key: 00-supabase-compat.sql
+          - name: tradeforge-bootstrap-sql
+            key: 0001_initial_schema.sql
+          - name: tradeforge-bootstrap-sql
+            key: 0002_harden_rls_drop_public_read.sql
+          - name: tradeforge-bootstrap-sql
+            key: 0003_reporter_rate_limit.sql
+          - name: tradeforge-bootstrap-sql
+            key: seed.sql
+  nodeMaintenanceWindow:
+    inProgress: false
+    reusePVC: true
+  resources:
+    requests:
+      cpu: 250m
+    limits:
+      memory: 2Gi
+  monitoring:
+    enablePodMonitor: true
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: garage-s3-tradeforge
+        serverName: tradeforge-pg-v1


### PR DESCRIPTION
## What

Adds a dedicated **PG17 CloudNativePG cluster `tradeforge-pg`** in the `database` namespace — the first piece of self-hosting TradeForge (Phase 3 of the plan). Kept separate from the shared `postgres17` because `wal_level=logical` (needed by `supabase/realtime`) is a cluster-wide setting.

## Contents

- `tradeforge.yaml` — Cluster CR: 1 instance, `wal_level=logical`, `managed.roles` (`authenticator` for PostgREST, `tradeforge_realtime` for Realtime), `initdb` bootstrap via `postInitApplicationSQLRefs`, barman-cloud plugin.
- `sql/00-supabase-compat.sql` — shim providing what Supabase's platform normally does: `auth` schema + `auth.jwt()/uid()/role()`, the `anon`/`authenticated`/`service_role`/`authenticator`/`tradeforge_realtime` roles + grants, and the `supabase_realtime` publication. Without this, self-hosted PostgREST RLS (which reads `auth.jwt() ->> 'sub'`) fails.
- `sql/0001_initial_schema.sql` — copied from tradeforge, with the Supabase **Storage** block stripped (depends on the `storage` schema that doesn't exist here; app parses CSV client-side).
- `sql/0002`, `sql/0003`, `sql/seed.sql` — copied verbatim (0003 adds the reporter rate-limit table/RPC).
- `objectstore-tradeforge.yaml` + `scheduledbackup.yaml` — barman-cloud backups to Garage bucket `tradeforge-pg`, daily.
- `kustomization.yaml` — registers the above + a `configMapGenerator` (`tradeforge-bootstrap-sql`, hash disabled so `postInitApplicationSQLRefs` resolves).

## Secrets / prereqs (done out-of-band)

- 1Password `cloudnative-pg` item: `tradeforge_authenticator_username/password`, `tradeforge_realtime_username/password`.
- Garage bucket `tradeforge-pg` created with the CNPG key granted access.

## Validation

- `kustomize build` clean.
- `kubectl apply --dry-run=server` — all resources accepted, including the CNPG validating webhook on the Cluster spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)