### PR TITLE
fix(database): authenticator inRoles + NOINHERIT for tradeforge-pg

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/tradeforge.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/tradeforge.yaml
@@ -29,6 +29,15 @@ spec:
         ensure: present
         login: true
         superuser: false
+        # CNPG manages these declaratively and overrides the shim. inherit:false
+        # keeps authenticator NOINHERIT (it must SET ROLE explicitly, never
+        # auto-inherit service_role's BYPASSRLS). inRoles re-establishes the
+        # membership CNPG would otherwise revoke, so PostgREST can switch roles.
+        inherit: false
+        inRoles:
+          - anon
+          - authenticated
+          - service_role
         passwordSecret:
           name: tradeforge-pg-authenticator
       - name: tradeforge_realtime # Realtime login role (created NOLOGIN by the shim)


### PR DESCRIPTION
Follow-up to #1728. Post-deploy verification showed the `authenticator` role had **0 role memberships** and was `INHERIT` — both wrong:

- CNPG `managed.roles` reconciles role membership/attributes declaratively and **reverted** the shim's `GRANT anon, authenticated, service_role TO authenticator`, so PostgREST could not `SET ROLE`.
- CNPG reset the role to `INHERIT`, which (once membership exists) would inherit `service_role`'s `BYPASSRLS` and **bypass all RLS** — a security bug.

Fix: declare `inRoles: [anon, authenticated, service_role]` and `inherit: false` on the managed `authenticator` role so CNPG enforces the correct, secure state.

Validated: `kustomize build` + `kubectl apply --dry-run=server` (CNPG webhook accepts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)