### PR TITLE
fix(database): tradeforge-pg 3 instances (HA)

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/tradeforge.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/tradeforge.yaml
@@ -5,7 +5,7 @@ kind: Cluster
 metadata:
   name: tradeforge-pg
 spec:
-  instances: 1 # dedicated cluster; bump to 2-3 later for HA
+  instances: 3 # HA across the 3 nodes, matching postgres17/outline
   imageName: ghcr.io/cloudnative-pg/postgresql:17
   primaryUpdateStrategy: unsupervised
   primaryUpdateMethod: switchover


### PR DESCRIPTION
Scale tradeforge-pg from 1 to 3 instances for high availability, matching postgres17/outline and using all 3 nodes. CNPG adds two streaming replicas to the existing primary.

Validated: kustomize build + kubectl apply --dry-run=server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)