### PR TITLE
feat(tradeforge): add PostgREST against tradeforge-pg

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -13,4 +13,5 @@ resources:
   - ./smtp-relay/ks.yaml
 #  - ./teslamate/ks.yaml
   - ./nginx/ks.yaml
+  - ./tradeforge/ks.yaml
   - ./wiki/ks.yaml

--- a/kubernetes/apps/default/tradeforge/app/externalsecret.yaml
+++ b/kubernetes/apps/default/tradeforge/app/externalsecret.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Application secrets for the TradeForge stack. Pulls DB role passwords from the
+# shared `cloudnative-pg` 1Password item and the app-layer keys (JWT signing
+# secret, anon/service JWTs, realtime keys) from the per-app `tradeforge` item.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tradeforge-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: tradeforge-secret
+    template:
+      data:
+        # --- PostgREST ---
+        PGRST_DB_URI: "postgres://authenticator:{{ .tradeforge_authenticator_password }}@tradeforge-pg-rw.database.svc.cluster.local:5432/tradeforge?sslmode=require"
+        PGRST_JWT_SECRET: "{{ .JWT_SECRET }}"
+        # --- Realtime (consumed when the realtime HelmRelease is added) ---
+        DB_PASSWORD: "{{ .tradeforge_realtime_password }}"
+        API_JWT_SECRET: "{{ .JWT_SECRET }}"
+        SECRET_KEY_BASE: "{{ .realtime_secret_key_base }}"
+        DB_ENC_KEY: "{{ .realtime_db_enc_key }}"
+        # --- shared keys for web (build) / reporter (later phases) ---
+        ANON_KEY: "{{ .anon_jwt }}"
+        SERVICE_ROLE_KEY: "{{ .service_role_jwt }}"
+  dataFrom:
+    - extract:
+        key: cloudnative-pg
+    - extract:
+        key: tradeforge

--- a/kubernetes/apps/default/tradeforge/app/helmrelease-postgrest.yaml
+++ b/kubernetes/apps/default/tradeforge/app/helmrelease-postgrest.yaml
@@ -1,0 +1,96 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app tradeforge-postgrest
+  namespace: &namespace default
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      postgrest:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 2
+        strategy: RollingUpdate
+        pod:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: *app
+                  app.kubernetes.io/instance: *app
+        containers:
+          app:
+            image:
+              repository: docker.io/postgrest/postgrest
+              tag: v12.2.12
+            env:
+              PGRST_DB_ANON_ROLE: anon
+              PGRST_DB_SCHEMAS: public
+              PGRST_DB_USE_LEGACY_GUCS: "false"
+              PGRST_SERVER_PORT: "3000"
+              PGRST_ADMIN_SERVER_PORT: "3001"
+            envFrom:
+              - secretRef:
+                  name: tradeforge-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /live
+                    port: 3001
+                  initialDelaySeconds: 5
+                  periodSeconds: 20
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ready
+                    port: 3001
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      app:
+        controller: postgrest
+        ports:
+          http:
+            port: 3000

--- a/kubernetes/apps/default/tradeforge/app/kustomization.yaml
+++ b/kubernetes/apps/default/tradeforge/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease-postgrest.yaml

--- a/kubernetes/apps/default/tradeforge/ks.yaml
+++ b/kubernetes/apps/default/tradeforge/ks.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tradeforge
+  namespace: &namespace default
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: database
+    - name: onepassword-store
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/default/tradeforge/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true


### PR DESCRIPTION
Phase 4 (part 1): PostgREST exposing the `tradeforge` database as the `/rest/v1` API — the drop-in replacement for Supabase REST. Connects as `authenticator`, validates HS256 JWTs with the shared `JWT_SECRET`, and relies on the RLS verified in #1728/#1730.

- `kubernetes/apps/default/tradeforge/ks.yaml` — Flux Kustomization, `dependsOn` cloudnative-pg-cluster + onepassword-store
- `app/externalsecret.yaml` — builds `PGRST_DB_URI` (sslmode=require) from the `cloudnative-pg` item + `PGRST_JWT_SECRET` from the new `tradeforge` item
- `app/helmrelease-postgrest.yaml` — `postgrest/postgrest:v12.2.12`, 2 replicas, `PGRST_DB_ANON_ROLE=anon`, admin-server health probes
- internal ClusterIP only (no public HTTPRoute yet — that comes at cutover)

Validated: kustomize build + kubectl --dry-run=server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)