### PR TITLE
feat(authentik): add TradeForge OIDC via blueprint (HS256)

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
@@ -1,0 +1,60 @@
+---
+# Authentik blueprint for TradeForge OIDC, mounted into /blueprints by the chart
+# (see helmrelease.yaml: blueprints.configMaps). Authentik discovers + applies it.
+#
+# TradeForge is HS256 (no signing_key => Authentik signs with client_secret), so
+# the same JWT_SECRET validates Authentik user tokens AND the static anon/service
+# keys in PostgREST/Realtime. The tradeforge-role scope mapping injects the
+# `role: authenticated` claim PostgREST reads to SET ROLE. client_id/secret come
+# from env (TRADEFORGE_*), provided via the authentik-secret ExternalSecret.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-blueprint-tradeforge
+data:
+  tradeforge.yaml: |
+    version: 1
+    metadata:
+      name: tradeforge-oidc
+    entries:
+      - id: tradeforge-role
+        model: authentik_providers_oauth2.scopemapping
+        identifiers:
+          name: tradeforge-role
+        attrs:
+          scope_name: tradeforge
+          description: "TradeForge: inject the PostgREST role claim"
+          expression: |
+            return {"role": "authenticated"}
+      - id: tradeforge-provider
+        model: authentik_providers_oauth2.oauth2provider
+        identifiers:
+          name: tradeforge
+        attrs:
+          client_type: public
+          client_id: !Env TRADEFORGE_OIDC_CLIENT_ID
+          client_secret: !Env TRADEFORGE_JWT_SECRET
+          sub_mode: user_uuid
+          access_token_validity: hours=4
+          authorization_flow: !Find [authentik_flows.flow, [slug, provider-authorization-implicit-consent]]
+          authentication_flow: !Find [authentik_flows.flow, [slug, authentication-flow]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, invalidation-flow]]
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+            - !KeyOf tradeforge-role
+          redirect_uris:
+            - matching_mode: strict
+              url: https://tradeforge-new.pipitonelabs.com/auth/callback
+            - matching_mode: strict
+              url: https://tradeforge.pipitonelabs.com/auth/callback
+      - id: tradeforge-app
+        model: authentik_core.application
+        identifiers:
+          slug: tradeforge
+        attrs:
+          name: TradeForge
+          provider: !KeyOf tradeforge-provider
+          meta_launch_url: https://tradeforge.pipitonelabs.com/
+          open_in_new_tab: true

--- a/kubernetes/apps/security/authentik/app/externalsecret.yaml
+++ b/kubernetes/apps/security/authentik/app/externalsecret.yaml
@@ -17,6 +17,11 @@ spec:
         AUTHENTIK_BOOTSTRAP_PASSWORD: '{{ .AUTHENTIK_PASSWORD }}'
         AUTHENTIK_BOOTSTRAP_TOKEN: '{{ .AUTHENTIK_TOKEN }}'
         AUTHENTIK_SECRET_KEY: '{{ .AUTHENTIK_SECRET_KEY }}'
+        # TradeForge OIDC (consumed by the tradeforge blueprint via !Env)
+        TRADEFORGE_JWT_SECRET: '{{ .JWT_SECRET }}'
+        TRADEFORGE_OIDC_CLIENT_ID: '{{ .oidc_client_id }}'
   dataFrom:
   - extract:
       key: authentik
+  - extract:
+      key: tradeforge

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -31,6 +31,9 @@ spec:
     remediation:
       retries: 3
   values:
+    blueprints:
+      configMaps:
+        - authentik-blueprint-tradeforge
     global:
       podAnnotations:
         secret.reloader.stakater.com/reload: authentik-secret

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: security
 resources:
+  - ./blueprint-tradeforge.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml


### PR DESCRIPTION
Adds the TradeForge OIDC app to Authentik via a **blueprint** (replacing the Terraform approach — Terraform was used *only* for Authentik and its Garage S3 state was lost in the MinIO→Garage migration). Blueprints are GitOps-native and need no external state.

- `blueprint-tradeforge.yaml` — ConfigMap mounted into `/blueprints` via the chart's `blueprints.configMaps`. Defines:
  - `tradeforge-role` scope mapping → injects `role: authenticated` (PostgREST reads this to `SET ROLE`)
  - HS256 OAuth2 provider (public/PKCE, **no `signing_key`** → signs with `client_secret` = `JWT_SECRET`; `sub_mode: user_uuid`; both redirect URIs)
  - the `TradeForge` application
- `externalsecret.yaml` — exposes `TRADEFORGE_JWT_SECRET` + `TRADEFORGE_OIDC_CLIENT_ID` from the `tradeforge` 1Password item (read by the blueprint via `!Env`)
- `helmrelease.yaml` — `blueprints.configMaps: [authentik-blueprint-tradeforge]`

Validated: `kustomize build` clean; inner blueprint parses (correct models, HS256, 4 mappings, role claim).

Note: existing Authentik apps (grafana/outline/etc.) keep working as-is; they can be migrated from Terraform to blueprints incrementally later, retiring `terraform/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)