### PR TITLE
feat(tradeforge): add supabase/realtime

### DIFF
--- a/kubernetes/apps/default/tradeforge/app/helmrelease-realtime.yaml
+++ b/kubernetes/apps/default/tradeforge/app/helmrelease-realtime.yaml
@@ -1,0 +1,97 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app tradeforge-realtime
+  namespace: &namespace default
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      realtime:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/supabase/realtime
+              tag: v2.76.5
+            env:
+              PORT: "4000"
+              DB_HOST: tradeforge-pg-rw.database.svc.cluster.local
+              DB_PORT: "5432"
+              DB_NAME: tradeforge
+              DB_USER: tradeforge_realtime
+              DB_AFTER_CONNECT_QUERY: "SET search_path TO _realtime"
+              APP_NAME: realtime
+              ERL_AFLAGS: -proto_dist inet_tcp
+              DNS_NODES: "''"
+              RLIMIT_NOFILE: "10000"
+              SEED_SELF_HOST: "true" # auto-provisions the realtime-dev tenant
+              RUN_JANITOR: "true"
+              DISABLE_HEALTHCHECK_LOGGING: "true"
+              # Realtime reuses the shared HS256 secret for the metrics endpoint
+              METRICS_JWT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: tradeforge-secret
+                    key: API_JWT_SECRET
+            envFrom:
+              # DB_PASSWORD, API_JWT_SECRET, SECRET_KEY_BASE, DB_ENC_KEY (others ignored)
+              - secretRef:
+                  name: tradeforge-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 4000
+                  initialDelaySeconds: 20
+                  periodSeconds: 20
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 4000
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      app:
+        controller: realtime
+        ports:
+          http:
+            port: 4000

--- a/kubernetes/apps/default/tradeforge/app/kustomization.yaml
+++ b/kubernetes/apps/default/tradeforge/app/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease-postgrest.yaml
+  - ./helmrelease-realtime.yaml


### PR DESCRIPTION
Adds `supabase/realtime:v2.76.5` against `tradeforge-pg` (wal_level=logical). `SEED_SELF_HOST=true` auto-provisions the `realtime-dev` tenant; connects as `tradeforge_realtime`; HS256 via the shared `API_JWT_SECRET`. Internal ClusterIP:4000 (HTTPRoute comes with the web/cutover step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)