### PR TITLE
fix(tradeforge): realtime root securityContext

### DIFF
--- a/kubernetes/apps/tradeforge/app/helmrelease-realtime.yaml
+++ b/kubernetes/apps/tradeforge/app/helmrelease-realtime.yaml
@@ -73,9 +73,9 @@ spec:
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 6
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities: { drop: ["ALL"] }
+            # The supabase/realtime entrypoint starts as root and drops to
+            # `nobody` itself via `sudo -E -u nobody` to run migrations + server,
+            # so it needs root + privilege escalation (no restrictive SC here).
             resources:
               requests:
                 cpu: 25m
@@ -84,9 +84,6 @@ spec:
                 memory: 1Gi
     defaultPodOptions:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
     service:


### PR DESCRIPTION
supabase/realtime's entrypoint runs `sudo -E -u nobody` (starts root, drops to nobody for migrations + server). The restrictive securityContext set the no-new-privileges flag and broke sudo → CrashLoopBackOff. Remove the strict SC so it runs as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)