### PR TITLE
fix(database): tradeforge_realtime superuser + realtime schemas

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/sql/00-supabase-compat.sql
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/sql/00-supabase-compat.sql
@@ -63,9 +63,13 @@ GRANT USAGE ON SCHEMA extensions TO anon, authenticated, service_role;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT USAGE, SELECT ON SEQUENCES TO anon, authenticated, service_role;
 
--- Realtime needs to create its _realtime schema + a logical replication slot --
+-- Realtime needs a logical replication slot + its two schemas. Supabase's
+-- platform pre-creates `_realtime` (control plane) and `realtime` (per-tenant
+-- data plane); recreate them here so a fresh bootstrap matches.
 GRANT ALL ON DATABASE tradeforge TO tradeforge_realtime;
 GRANT ALL ON SCHEMA public TO tradeforge_realtime;
+CREATE SCHEMA IF NOT EXISTS _realtime AUTHORIZATION tradeforge_realtime;
+CREATE SCHEMA IF NOT EXISTS realtime AUTHORIZATION tradeforge_realtime;
 
 -- Empty publication that 0001 ALTERs ... ADD TABLE into ----------------------
 DO $$

--- a/kubernetes/apps/database/cloudnative-pg/cluster/tradeforge.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/tradeforge.yaml
@@ -44,6 +44,11 @@ spec:
         ensure: present
         login: true
         replication: true
+        # supabase/realtime tenant migrations create event triggers and set
+        # superuser-only GUCs (e.g. log_min_messages); Supabase runs realtime as
+        # the superuser supabase_admin. This role is realtime-only; authenticator
+        # stays non-superuser so RLS is always enforced for app traffic.
+        superuser: true
         passwordSecret:
           name: tradeforge-pg-realtime
   bootstrap:


### PR DESCRIPTION
supabase/realtime tenant setup needs a superuser (creates event triggers, sets log_min_messages) — Supabase runs realtime as supabase_admin. Grant superuser to the realtime-only role (authenticator stays non-superuser → RLS intact). Also pre-create `_realtime` + `realtime` schemas in the bootstrap shim for fresh-bootstrap parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)