### PR TITLE
feat(authentik): restrict TradeForge to Self Hosted group

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
@@ -58,3 +58,12 @@ data:
           provider: !KeyOf tradeforge-provider
           meta_launch_url: https://tradeforge.pipitonelabs.com/
           open_in_new_tab: true
+      # Restrict access to the "Self Hosted" group (your account must be a member)
+      - id: tradeforge-access
+        model: authentik_policies.policybinding
+        identifiers:
+          target: !KeyOf tradeforge-app
+          group: !Find [authentik_core.group, [name, "Self Hosted"]]
+          order: 0
+        attrs:
+          enabled: true


### PR DESCRIPTION
Adds a policy binding to the TradeForge blueprint so only the **Self Hosted** group can access the app (was open to all authenticated users). Your account must be a member of that group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)