### PR TITLE
feat(tradeforge): web + reporter + public HTTPRoute

### DIFF
--- a/kubernetes/apps/tradeforge/app/externalsecret-ghcr.yaml
+++ b/kubernetes/apps/tradeforge/app/externalsecret-ghcr.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ghcr-login
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: ghcr-login
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {"auths":{"ghcr.io":{"username":"{{ .ghcr_username }}","password":"{{ .ghcr_token }}","auth":"{{ printf "%s:%s" .ghcr_username .ghcr_token | b64enc }}"}}}
+  data:
+    - secretKey: ghcr_username
+      remoteRef:
+        key: tradeforge
+        property: ghcr_username
+    - secretKey: ghcr_token
+      remoteRef:
+        key: tradeforge
+        property: ghcr_token

--- a/kubernetes/apps/tradeforge/app/externalsecret-ghcr.yaml
+++ b/kubernetes/apps/tradeforge/app/externalsecret-ghcr.yaml
@@ -15,13 +15,9 @@ spec:
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: |
-          {"auths":{"ghcr.io":{"username":"{{ .ghcr_username }}","password":"{{ .ghcr_token }}","auth":"{{ printf "%s:%s" .ghcr_username .ghcr_token | b64enc }}"}}}
+          {"auths":{"ghcr.io":{"username":"flux","password":"{{ .FLUX_GITHUB_TOKEN }}","auth":"{{ printf "flux:%s" .FLUX_GITHUB_TOKEN | b64enc }}"}}}
   data:
-    - secretKey: ghcr_username
+    - secretKey: FLUX_GITHUB_TOKEN
       remoteRef:
-        key: tradeforge
-        property: ghcr_username
-    - secretKey: ghcr_token
-      remoteRef:
-        key: tradeforge
-        property: ghcr_token
+        key: flux
+        property: FLUX_GITHUB_TOKEN

--- a/kubernetes/apps/tradeforge/app/helmrelease-reporter.yaml
+++ b/kubernetes/apps/tradeforge/app/helmrelease-reporter.yaml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app tradeforge-reporter
+  namespace: &namespace tradeforge
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      reporter:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 2
+        containers:
+          app:
+            image:
+              repository: ghcr.io/pipitonelabs/tradeforge-selfhost-reporter
+              tag: latest # renovate-managed once first image is published
+            env:
+              # Reporter writes via PostgREST (internal) as the service role.
+              SUPABASE_URL: http://tradeforge-postgrest.tradeforge.svc.cluster.local:3000
+              SUPABASE_SERVICE_ROLE_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: tradeforge-secret
+                    key: SERVICE_ROLE_KEY
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8000
+                  initialDelaySeconds: 5
+                  periodSeconds: 20
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probe
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      app:
+        controller: reporter
+        ports:
+          http:
+            port: 8000

--- a/kubernetes/apps/tradeforge/app/helmrelease-reporter.yaml
+++ b/kubernetes/apps/tradeforge/app/helmrelease-reporter.yaml
@@ -60,6 +60,8 @@ spec:
               limits:
                 memory: 256Mi
     defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-login
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kubernetes/apps/tradeforge/app/helmrelease-web.yaml
+++ b/kubernetes/apps/tradeforge/app/helmrelease-web.yaml
@@ -1,0 +1,74 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app tradeforge-web
+  namespace: &namespace tradeforge
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      web:
+        replicas: 2
+        strategy: RollingUpdate
+        pod:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: *app
+                  app.kubernetes.io/instance: *app
+        containers:
+          app:
+            image:
+              repository: ghcr.io/pipitonelabs/tradeforge-selfhost-web
+              tag: latest # renovate-managed once first image is published
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 20
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probe
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101 # nginx-unprivileged
+        runAsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      app:
+        controller: web
+        ports:
+          http:
+            port: 8080

--- a/kubernetes/apps/tradeforge/app/helmrelease-web.yaml
+++ b/kubernetes/apps/tradeforge/app/helmrelease-web.yaml
@@ -60,6 +60,8 @@ spec:
               limits:
                 memory: 128Mi
     defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-login
       securityContext:
         runAsNonRoot: true
         runAsUser: 101 # nginx-unprivileged

--- a/kubernetes/apps/tradeforge/app/httproute.yaml
+++ b/kubernetes/apps/tradeforge/app/httproute.yaml
@@ -2,14 +2,13 @@
 # yaml-language-server: $schema=https://kube-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
 # Single public route fronting the whole stack. The SPA + supabase-js see one
 # origin; paths fan out to the backends (mirrors Supabase's gateway layout).
-# Hostname is the cutover host (tradeforge.pipitonelabs.com is still the Vercel
-# prod app); swap to tradeforge.pipitonelabs.com at final cutover.
+# external-dns auto-creates the Cloudflare record (envoy-external) for this host.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: tradeforge
 spec:
-  hostnames: ["tradeforge-new.pipitonelabs.com"]
+  hostnames: ["tradeforge.pipitonelabs.com"]
   parentRefs:
     - name: envoy-external
       namespace: networking

--- a/kubernetes/apps/tradeforge/app/httproute.yaml
+++ b/kubernetes/apps/tradeforge/app/httproute.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# Single public route fronting the whole stack. The SPA + supabase-js see one
+# origin; paths fan out to the backends (mirrors Supabase's gateway layout).
+# Hostname is the cutover host (tradeforge.pipitonelabs.com is still the Vercel
+# prod app); swap to tradeforge.pipitonelabs.com at final cutover.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tradeforge
+spec:
+  hostnames: ["tradeforge-new.pipitonelabs.com"]
+  parentRefs:
+    - name: envoy-external
+      namespace: networking
+  rules:
+    # PostgREST serves at root; strip the /rest/v1 prefix.
+    - matches:
+        - path: { type: PathPrefix, value: /rest/v1 }
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path: { type: ReplacePrefixMatch, replacePrefixMatch: / }
+      backendRefs:
+        - name: tradeforge-postgrest
+          port: 3000
+    # Realtime (Phoenix) serves the socket at /socket; map /realtime/v1 -> /socket.
+    # VALIDATE at cutover: confirm the WS connects (devtools -> WS).
+    - matches:
+        - path: { type: PathPrefix, value: /realtime/v1 }
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path: { type: ReplacePrefixMatch, replacePrefixMatch: /socket }
+      backendRefs:
+        - name: tradeforge-realtime
+          port: 4000
+    # Reporter handles any non-/health path as a trade POST; no rewrite needed.
+    - matches:
+        - path: { type: PathPrefix, value: /functions/v1/ticino-reporter }
+      backendRefs:
+        - name: tradeforge-reporter
+          port: 8000
+    # Everything else -> the SPA.
+    - matches:
+        - path: { type: PathPrefix, value: / }
+      backendRefs:
+        - name: tradeforge-web
+          port: 8080

--- a/kubernetes/apps/tradeforge/app/kustomization.yaml
+++ b/kubernetes/apps/tradeforge/app/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-ghcr.yaml
   - ./helmrelease-postgrest.yaml
   - ./helmrelease-realtime.yaml
   - ./helmrelease-reporter.yaml

--- a/kubernetes/apps/tradeforge/app/kustomization.yaml
+++ b/kubernetes/apps/tradeforge/app/kustomization.yaml
@@ -5,3 +5,6 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease-postgrest.yaml
   - ./helmrelease-realtime.yaml
+  - ./helmrelease-reporter.yaml
+  - ./helmrelease-web.yaml
+  - ./httproute.yaml


### PR DESCRIPTION
Adds the frontend tier: **web** (nginx SPA) + **reporter** (Deno) HelmReleases + a single **envoy-external** HTTPRoute at **`tradeforge.pipitonelabs.com`** (external-dns auto-creates the Cloudflare record). Fans `/`→web, `/rest/v1`→postgrest, `/realtime/v1`→realtime, `/functions/v1`→reporter.

Images from the `pipitonelabs/tradeforge-selfhost` CI.

⚠️ **Merge only after** the two GHCR packages are **public** (else web/reporter ImagePullBackOff). Validate the realtime `/realtime/v1`→`/socket` rewrite after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)