### PR TITLE
feat(authentik): TradeForge redirect URI -> final host

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
@@ -46,8 +46,6 @@ data:
             - !KeyOf tradeforge-role
           redirect_uris:
             - matching_mode: strict
-              url: https://tradeforge-new.pipitonelabs.com/auth/callback
-            - matching_mode: strict
               url: https://tradeforge.pipitonelabs.com/auth/callback
       - id: tradeforge-app
         model: authentik_core.application


### PR DESCRIPTION
Drops the temporary `tradeforge-new` redirect URI; TradeForge uses the final `tradeforge.pipitonelabs.com/auth/callback`. `tradeforge.pipitonelabs.com` is currently unused (no Vercel record), so no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)