### PR TITLE
fix(tradeforge): use classic PAT for GHCR image pull

### DIFF
--- a/kubernetes/apps/tradeforge/app/externalsecret-ghcr.yaml
+++ b/kubernetes/apps/tradeforge/app/externalsecret-ghcr.yaml
@@ -15,9 +15,9 @@ spec:
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: |
-          {"auths":{"ghcr.io":{"username":"flux","password":"{{ .FLUX_GITHUB_TOKEN }}","auth":"{{ printf "flux:%s" .FLUX_GITHUB_TOKEN | b64enc }}"}}}
+          {"auths":{"ghcr.io":{"username":"pipitonelabs","password":"{{ .tradeforge_github_pat }}","auth":"{{ printf "pipitonelabs:%s" .tradeforge_github_pat | b64enc }}"}}}
   data:
-    - secretKey: FLUX_GITHUB_TOKEN
+    - secretKey: tradeforge_github_pat
       remoteRef:
-        key: flux
-        property: FLUX_GITHUB_TOKEN
+        key: tradeforge
+        property: tradeforge_github_pat


### PR DESCRIPTION
## Summary
- Switch GHCR pull secret from Flux fine-grained PAT to a classic PAT with `read:packages` scope
- Token stored as `tradeforge_github_pat` in the `tradeforge` 1Password item

## Test plan
- [ ] ESO syncs ghcr-login secret successfully
- [ ] web + reporter pods pull images without 403/401

🤖 Generated with [Claude Code](https://claude.com/claude-code)