### PR TITLE
fix(tradeforge): set reporter runAsUser for deno image

### DIFF
--- a/kubernetes/apps/tradeforge/app/helmrelease-reporter.yaml
+++ b/kubernetes/apps/tradeforge/app/helmrelease-reporter.yaml
@@ -64,6 +64,8 @@ spec:
         - name: ghcr-login
       securityContext:
         runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
     service:


### PR DESCRIPTION
## Summary
- Reporter pods fail with `runAsNonRoot and image has non-numeric user (deno)`
- Set `runAsUser: 1000` / `runAsGroup: 1000` matching the deno image's UID/GID

## Test plan
- [ ] Reporter pods start without CreateContainerConfigError

🤖 Generated with [Claude Code](https://claude.com/claude-code)