### PR TITLE
fix(authentik): tradeforge OIDC provider → confidential for auth code + PKCE

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
@@ -31,7 +31,7 @@ data:
         identifiers:
           name: tradeforge
         attrs:
-          client_type: public
+          client_type: confidential
           client_id: !Env TRADEFORGE_OIDC_CLIENT_ID
           client_secret: !Env TRADEFORGE_JWT_SECRET
           sub_mode: user_uuid


### PR DESCRIPTION
## Summary
- Authentik `public` client_type only allows implicit flow, rejecting `authorization_code` grant
- The SPA uses `response_type=code` + PKCE (S256), which requires `confidential` client_type
- PKCE substitutes for client_secret at the token endpoint

## Test plan
- [ ] Sign in at tradeforge.pipitonelabs.com no longer returns "The request is otherwise malformed"
- [ ] OIDC callback completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)