### PR TITLE
fix(authentik): enable authorization_code grant for tradeforge OIDC

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
@@ -36,6 +36,10 @@ data:
           client_secret: !Env TRADEFORGE_JWT_SECRET
           sub_mode: user_uuid
           access_token_validity: hours=4
+          grant_types:
+            - authorization_code
+            - refresh_token
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
           authorization_flow: !Find [authentik_flows.flow, [slug, provider-authorization-implicit-consent]]
           authentication_flow: !Find [authentik_flows.flow, [slug, authentication-flow]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, invalidation-flow]]


### PR DESCRIPTION
## Summary
- Blueprint-created providers default to empty `grant_types[]`, blocking all auth flows
- Explicitly set `authorization_code` + `refresh_token` grant types
- Add signing key for JWT signing (uses existing authentik self-signed cert)

## Test plan
- [ ] Sign in at tradeforge.pipitonelabs.com completes without "malformed request" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)