### PR TITLE
fix(authentik): public client + explicit grant_types for tradeforge OIDC

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
@@ -31,7 +31,7 @@ data:
         identifiers:
           name: tradeforge
         attrs:
-          client_type: confidential
+          client_type: public
           client_id: !Env TRADEFORGE_OIDC_CLIENT_ID
           client_secret: !Env TRADEFORGE_JWT_SECRET
           sub_mode: user_uuid


### PR DESCRIPTION
## Summary
- Confidential client requires client_secret at token endpoint — SPAs can't do that
- Revert to public client_type, keep explicit `grant_types: [authorization_code, refresh_token]`
- The real fix was always the empty grant_types array, not the client_type

## Test plan
- [ ] OIDC login flow completes at tradeforge.pipitonelabs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)