### PR TITLE
fix(authentik): register tradeforge post-logout redirect URI

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
@@ -51,6 +51,9 @@ data:
           redirect_uris:
             - matching_mode: strict
               url: https://tradeforge.pipitonelabs.com/auth/callback
+            - matching_mode: strict
+              url: https://tradeforge.pipitonelabs.com
+              redirect_uri_type: logout
       - id: tradeforge-app
         model: authentik_core.application
         identifiers:


### PR DESCRIPTION
## Summary
- Logout redirect to tradeforge.pipitonelabs.com fails with "Bad Request" because the URI isn't registered
- Add it as a `redirect_uri_type: logout` entry in the blueprint

## Test plan
- [ ] Sign out from tradeforge redirects back cleanly instead of "Bad Request"

🤖 Generated with [Claude Code](https://claude.com/claude-code)