### PR TITLE
fix(authentik): remove signing_key to restore HS256 for PostgREST compat

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
@@ -39,7 +39,6 @@ data:
           grant_types:
             - authorization_code
             - refresh_token
-          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
           authorization_flow: !Find [authentik_flows.flow, [slug, provider-authorization-implicit-consent]]
           authentication_flow: !Find [authentik_flows.flow, [slug, authentication-flow]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, invalidation-flow]]


### PR DESCRIPTION
## Summary
- signing_key made Authentik sign user JWTs with RS256, but PostgREST validates with HS256 JWT_SECRET
- Remove signing_key → Authentik uses client_secret (= JWT_SECRET) for HS256 signing
- All tokens (user, anon, service_role) validated by one shared HS256 key

## Test plan
- [ ] After login, trade data loads at tradeforge.pipitonelabs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)