### PR TITLE
fix(authentik): explicitly null signing_key for HS256 tokens

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprint-tradeforge.yaml
@@ -39,6 +39,10 @@ data:
           grant_types:
             - authorization_code
             - refresh_token
+          # Explicit null: omitting it would leave the prior value set.
+          # No signing key => Authentik signs tokens HS256 with client_secret,
+          # so PostgREST/Realtime validate them with the shared JWT_SECRET.
+          signing_key: null
           authorization_flow: !Find [authentik_flows.flow, [slug, provider-authorization-implicit-consent]]
           authentication_flow: !Find [authentik_flows.flow, [slug, authentication-flow]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, invalidation-flow]]


### PR DESCRIPTION
## Summary
- Removing `signing_key` from the blueprint didn't clear it — Authentik blueprints only apply present fields
- The provider kept the RS256 cert, so user tokens stayed RS256 and PostgREST (HS256) rejected them
- Set `signing_key: null` explicitly to force HS256 signing with client_secret

## Test plan
- [ ] After re-login, trade data loads at tradeforge.pipitonelabs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)