### PR TITLE
fix(tradeforge): pin web + reporter image digests (Spegel stale latest)

### DIFF
--- a/kubernetes/apps/tradeforge/app/helmrelease-reporter.yaml
+++ b/kubernetes/apps/tradeforge/app/helmrelease-reporter.yaml
@@ -28,7 +28,10 @@ spec:
           app:
             image:
               repository: ghcr.io/pipitonelabs/tradeforge-selfhost-reporter
-              tag: latest # renovate-managed once first image is published
+              # Digest-pinned: Spegel serves the mutable `latest` tag from peer
+              # cache, so a bare `latest` won't pull new builds. Renovate bumps
+              # the digest on each new image.
+              tag: latest@sha256:a44cc61f062b5225b0c581d2c52f3a32476c1d70f6d05c9d02b3deab68fdee72
             env:
               # Reporter writes via PostgREST (internal) as the service role.
               SUPABASE_URL: http://tradeforge-postgrest.tradeforge.svc.cluster.local:3000

--- a/kubernetes/apps/tradeforge/app/helmrelease-web.yaml
+++ b/kubernetes/apps/tradeforge/app/helmrelease-web.yaml
@@ -36,7 +36,10 @@ spec:
           app:
             image:
               repository: ghcr.io/pipitonelabs/tradeforge-selfhost-web
-              tag: latest # renovate-managed once first image is published
+              # Digest-pinned: Spegel serves the mutable `latest` tag from peer
+              # cache, so a bare `latest` won't pull new builds. Renovate bumps
+              # the digest on each new image.
+              tag: latest@sha256:193d0cbea607bb5a4e9287538d50252bfec9cf5c5194e9631793b72e6f5df712
             probes:
               liveness: &probe
                 enabled: true


### PR DESCRIPTION
## Summary
- Spegel (P2P image cache) resolves the mutable `latest` tag to a cached digest, so new CI builds weren't pulled despite `imagePullPolicy: Always`
- Pin the OCI index digest so containerd pulls by content hash, matching the repo's existing digest-pinning convention
- Renovate will bump the digests on subsequent builds

## Test plan
- [ ] web pods run the new digest (EnsureProfile fix)
- [ ] reporter pods run the pinned digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)