### PR TITLE
chore(tradeforge-web): bump image digest for stats-summary + max-drawdown

### DIFF
--- a/kubernetes/apps/tradeforge/app/helmrelease-web.yaml
+++ b/kubernetes/apps/tradeforge/app/helmrelease-web.yaml
@@ -39,7 +39,7 @@ spec:
               # Digest-pinned: Spegel serves the mutable `latest` tag from peer
               # cache, so a bare `latest` won't pull new builds. Renovate bumps
               # the digest on each new image.
-              tag: latest@sha256:7d7015a808ecc34cf6cfa41f164d369d432ead9f00da8814da6a748faa90799b
+              tag: latest@sha256:cf4f9a531b051f4c5e1eb5b2c3a2e76a15e4b128cd0ca9d112c026e732b7f798
             probes:
               liveness: &probe
                 enabled: true

--- a/kubernetes/apps/tradeforge/app/helmrelease-web.yaml
+++ b/kubernetes/apps/tradeforge/app/helmrelease-web.yaml
@@ -39,7 +39,7 @@ spec:
               # Digest-pinned: Spegel serves the mutable `latest` tag from peer
               # cache, so a bare `latest` won't pull new builds. Renovate bumps
               # the digest on each new image.
-              tag: latest@sha256:cf4f9a531b051f4c5e1eb5b2c3a2e76a15e4b128cd0ca9d112c026e732b7f798
+              tag: latest@sha256:aafd18d6abfaeae3122c8893a8b74c3b40064d52e547c1d6fd5489b5fd7256b8
             probes:
               liveness: &probe
                 enabled: true


### PR DESCRIPTION
## Summary
Bumps `ghcr.io/pipitonelabs/tradeforge-selfhost-web` digest to `sha256:aafd18d6…`, picking up two merged PRs in `tradeforge-selfhost`:

- **PR #4** — Stats Summary page port (Ticino trade analyser)
- **PR #5** — Maximum Drawdown section on the Stats Summary → Overview tab

Built from [tradeforge-selfhost@bb9e3b8](https://github.com/pipitonelabs/tradeforge-selfhost/commit/bb9e3b8).

## Why manual?
Renovate workflow gets 401 from ghcr.io — the package is private and Renovate has no read:packages token. Manual bump until that's resolved (make package public, or add a GHCR PAT + `RENOVATE_HOST_RULES`).

## Test plan
- [ ] Flux reconciles the HelmRelease
- [ ] New pod rolls out and `/stats-summary` renders, including the MDD section + shaded equity-curve overlay