### PR TITLE
feat(observability): migrate kromgo config to v0.10 schema

### DIFF
--- a/kubernetes/apps/observability/kromgo/app/resources/config.yaml
+++ b/kubernetes/apps/observability/kromgo/app/resources/config.yaml
@@ -1,80 +1,66 @@
----
-metrics:
-  - name: talos_version
+# yaml-language-server: $schema=https://raw.githubusercontent.com/home-operations/kromgo/main/config.schema.json
+
+badges:
+  - title: Talos
+    id: talos_version
     query: label_replace(node_os_info{name="Talos"}, "version_id", "$1", "version_id", "v(.+)")
-    label: version_id
-    title: Talos
+    valueExpr: labels["version_id"]
+    icon: si:talos
 
-  - name: kubernetes_version
+  - title: Kubernetes
+    id: kubernetes_version
     query: label_replace(kubernetes_build_info{service="kubernetes"}, "git_version", "$1", "git_version", "v(.+)")
-    label: git_version
-    title: Kubernetes
+    valueExpr: labels["git_version"]
+    icon: si:kubernetes
 
-  - name: flux_version
-    query: label_replace(flux_instance_info, "revision", "$1", "revision", "v(.+)@sha256:(.+)")
-    label: revision
-    title: Flux
+  - title: Flux
+    id: flux_version
+    query: label_replace(flux_instance_info, "revision", "$1", "revision", "v(.+)@sha256:.+")
+    valueExpr: labels["revision"]
+    icon: si:flux
 
-  - name: cluster_node_count
+  - title: Nodes
+    id: cluster_node_count
     query: count(count by (node) (kube_node_status_condition{condition="Ready"}))
-    colors:
-      - { color: green, min: 0, max: 9999 }
-    title: Nodes
+    colorExpr: '"green"'
 
-  - name: cluster_pod_count
+  - title: Pods
+    id: cluster_pod_count
     query: sum(kube_pod_status_phase{phase="Running"})
-    colors:
-      - { color: green, min: 0, max: 9999 }
-    title: Pods
+    valueExpr: humanizeCommas(result)
+    colorExpr: '"green"'
 
-  - name: cluster_cpu_usage
+  - title: CPU
+    id: cluster_cpu_usage
     query: round(avg(cluster:node_cpu:ratio_rate5m) * 100, 0.1)
-    suffix: "%"
-    colors:
-      - { color: green, min: 0, max: 35 }
-      - { color: orange, min: 36, max: 75 }
-      - { color: red, min: 76, max: 9999 }
-    title: CPU
+    valueExpr: string(result) + "%"
+    colorExpr: 'colorScale(result, [35.0, 75.0], ["green", "orange", "red"])'
 
-  - name: cluster_memory_usage
+  - title: Memory
+    id: cluster_memory_usage
     query: round(sum(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes) * 100, 0.1)
-    suffix: "%"
-    colors:
-      - { color: green, min: 0, max: 35 }
-      - { color: orange, min: 36, max: 75 }
-      - { color: red, min: 76, max: 9999 }
-    title: Memory
+    valueExpr: string(result) + "%"
+    colorExpr: 'colorScale(result, [35.0, 75.0], ["green", "orange", "red"])'
 
-  - name: cluster_power_usage
+  - title: Power
+    id: cluster_power_usage
     query: round(upsHighPrecOutputLoad, 0.1)
-    suffix: w
-    colors:
-      - { color: green, min: 0, max: 400 }
-      - { color: orange, min: 401, max: 750 }
-      - { color: red, min: 751, max: 9999 }
-    title: Power
+    valueExpr: humanizeCommas(math.round(result)) + "w"
+    colorExpr: 'colorScale(result, [400.0, 750.0], ["green", "orange", "red"])'
 
-  - name: cluster_age_days
-    query: round((time() - min(kube_node_created)) / 86400)
-    suffix: d
-    colors:
-      - { color: green, min: 0, max: 180 }
-      - { color: orange, min: 181, max: 360 }
-      - { color: red, min: 361, max: 9999 }
-    title: Age
+  - title: Age
+    id: cluster_birth_age
+    query: round(time() - min(kube_node_created))
+    valueExpr: humanizeDurationDays(result)
+    colorExpr: 'colorScale(result, [15552000.0, 31104000.0], ["green", "orange", "red"])'
 
-  - name: cluster_uptime_days
-    query: round(avg(node_time_seconds - node_boot_time_seconds) / 86400)
-    suffix: d
-    colors:
-      - { color: green, min: 0, max: 180 }
-      - { color: orange, min: 181, max: 360 }
-      - { color: red, min: 361, max: 9999 }
-    title: Uptime
+  - title: Uptime
+    id: cluster_uptime_age
+    query: round(avg(node_time_seconds - node_boot_time_seconds))
+    valueExpr: humanizeDurationDays(result)
+    colorExpr: 'colorScale(result, [15552000.0, 31104000.0], ["green", "orange", "red"])'
 
-  - name: cluster_alert_count
+  - title: Alerts
+    id: cluster_alert_count
     query: alertmanager_alerts{state="active"} - 1 # Ignore Watchdog
-    colors:
-      - { color: "green", min: 0, max: 0 }
-      - { color: "red", min: 1, max: 9999 }
-    title: Alerts
+    colorExpr: 'colorScale(result, [1.0], ["green", "red"])'


### PR DESCRIPTION
## Summary

- Rewrites `config.yaml` from the legacy `metrics:` format to the new `badges:` schema required by kromgo v0.10
- Replaces `colors:` min/max arrays with `colorExpr` using `colorScale()` expressions
- Replaces `label:` / `suffix:` with `valueExpr` (e.g. `humanizeDurationDays`, `string(result) + "%"`)
- Adds Simple Icons (`si:talos`, `si:kubernetes`, `si:flux`) to version badges
- Renames age/uptime IDs to `cluster_birth_age` / `cluster_uptime_age` to match upstream convention
- Adds `yaml-language-server` schema header for IDE validation

## Test plan

- [ ] Confirm Flux reconciles the updated ConfigMap without errors
- [ ] Verify badges render at `https://kromgo.pipitonelabs.com/<id>?format=badge`
- [ ] Update README badge URLs for renamed IDs (`cluster_birth_age`, `cluster_uptime_age`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)