### PR TITLE
fix(observability): update kromgo to home-operations image and fix config mount

### DIFF
--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -27,12 +27,12 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/kashalls/kromgo
-              tag: v0.10.0@sha256:965ecc92d68dc1a4a969397855367bbc70da03227a941ea607b73bb7e0b78fd6
+              repository: ghcr.io/home-operations/kromgo
+              tag: 0.14.0@sha256:94ee0e2561048dc4637ca21b9926b76d87c15baf951678c7febb852269b7e10b
             env:
               PROMETHEUS_URL: http://prometheus-operated.observability.svc.cluster.local:9090
-              HEALTH_PORT: &healthPort 8888
-              SERVER_PORT: &port 8080
+              HEALTH_PORT: &healthPort 8080
+              SERVER_PORT: &port 80
             probes:
               liveness: &probes
                 enabled: true
@@ -43,7 +43,7 @@ spec:
                     port: *healthPort
                   initialDelaySeconds: 0
                   periodSeconds: 10
-                  timeoutSeconds: 1
+                  timeoutSeconds: 5
                   failureThreshold: 3
               readiness: *probes
             resources:
@@ -65,7 +65,7 @@ spec:
         type: configMap
         name: kromgo-configmap
         globalMounts:
-          - path: /kromgo/config.yaml
+          - path: /config/config.yaml
             subPath: config.yaml
             readOnly: true
     route:


### PR DESCRIPTION
## Summary

- Switch image from `kashalls/kromgo:v0.10.0` → `home-operations/kromgo:0.14.0` (supports the `badges:` schema)
- Fix config mount path: `/kromgo/config.yaml` → `/config/config.yaml` (where the binary expects it)
- Update ports to match upstream reference: `HEALTH_PORT=8080`, `SERVER_PORT=80`

The previous v0.10.0 image predated the `badges:` schema, causing "metric not found" on all badges.

## Test plan

- [ ] Confirm pods come up healthy after Flux reconciles
- [ ] Verify badges render at `https://kromgo.pipitonelabs.com/<id>?format=badge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)