### PR TITLE
fix(observability): fix kromgo badge path, clean ks.yaml, add buddy badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ _... managed with Flux, Renovate, and GitHub Actions_ <img src="https://fonts.gs
 <div align="center">
 
 [![Discord](https://img.shields.io/discord/673534664354430999?style=for-the-badge&label&logo=discord&logoColor=white&color=blue)](https://discord.gg/home-operations)&nbsp;&nbsp;
-[![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Ftalos_version&style=for-the-badge&logo=talos&logoColor=white&color=blue&label=%20)](https://talos.dev)&nbsp;&nbsp;
-[![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fkubernetes_version&style=for-the-badge&logo=kubernetes&logoColor=white&color=blue&label=%20)](https://kubernetes.io)&nbsp;&nbsp;
-[![Flux](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fflux_version&style=for-the-badge&logo=flux&logoColor=white&color=blue&label=%20)](https://fluxcd.io)&nbsp;&nbsp;
+[![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fbadges%2Ftalos_version&style=for-the-badge&logo=talos&logoColor=white&color=blue&label=%20)](https://talos.dev)&nbsp;&nbsp;
+[![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fbadges%2Fkubernetes_version&style=for-the-badge&logo=kubernetes&logoColor=white&color=blue&label=%20)](https://kubernetes.io)&nbsp;&nbsp;
+[![Flux](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fbadges%2Fflux_version&style=for-the-badge&logo=flux&logoColor=white&color=blue&label=%20)](https://fluxcd.io)&nbsp;&nbsp;
 [![Renovate](https://img.shields.io/github/actions/workflow/status/pipitonelabs/k8s-gitops/renovate.yaml?branch=main&label=&logo=renovatebot&style=for-the-badge&color=blue)](https://github.com/pipitonelabs/k8s-gitops/actions/workflows/renovate.yaml)
 
 </div>
@@ -26,13 +26,13 @@ _... managed with Flux, Renovate, and GitHub Actions_ <img src="https://fonts.gs
 
 <div align="center">
 
-[![Age-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fcluster_age_days&style=flat-square&label=Age)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Uptime-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fcluster_uptime_days&style=flat-square&label=Uptime)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Node-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fcluster_node_count&style=flat-square&label=Nodes)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Pod-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fcluster_pod_count&style=flat-square&label=Pods)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![CPU-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fcluster_cpu_usage&style=flat-square&label=CPU)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Memory-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fcluster_memory_usage&style=flat-square&label=Memory)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Alerts](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fcluster_alert_count&style=flat-square&label=Alerts)](https://github.com/kashalls/kromgo)
+[![Age-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fbadges%2Fcluster_birth_age&style=flat-square&label=Age)](https://github.com/home-operations/kromgo)&nbsp;&nbsp;
+[![Uptime-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fbadges%2Fcluster_uptime_age&style=flat-square&label=Uptime)](https://github.com/home-operations/kromgo)&nbsp;&nbsp;
+[![Node-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fbadges%2Fcluster_node_count&style=flat-square&label=Nodes)](https://github.com/home-operations/kromgo)&nbsp;&nbsp;
+[![Pod-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fbadges%2Fcluster_pod_count&style=flat-square&label=Pods)](https://github.com/home-operations/kromgo)&nbsp;&nbsp;
+[![CPU-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fbadges%2Fcluster_cpu_usage&style=flat-square&label=CPU)](https://github.com/home-operations/kromgo)&nbsp;&nbsp;
+[![Memory-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fbadges%2Fcluster_memory_usage&style=flat-square&label=Memory)](https://github.com/home-operations/kromgo)&nbsp;&nbsp;
+[![Alerts](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.pipitonelabs.com%2Fbadges%2Fcluster_alert_count&style=flat-square&label=Alerts)](https://github.com/home-operations/kromgo)
 
 </div>
 

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -72,7 +72,7 @@ spec:
       app:
         annotations:
           gatus.home-operations.com/endpoint: |-
-            url: https://{{ .Release.Name }}.pipitonelabs.com/talos_version
+            url: https://{{ .Release.Name }}.pipitonelabs.com/badges/talos_version
         hostnames:
           - "{{ .Release.Name }}.pipitonelabs.com"
         parentRefs:

--- a/kubernetes/apps/observability/kromgo/app/resources/config.yaml
+++ b/kubernetes/apps/observability/kromgo/app/resources/config.yaml
@@ -64,24 +64,3 @@ badges:
     id: cluster_alert_count
     query: alertmanager_alerts{state="active"} - 1 # Ignore Watchdog
     colorExpr: 'colorScale(result, [1.0], ["green", "red"])'
-
-  - title: Home Internet
-    id: buddy_ping
-    query: gatus_results_endpoint_success{key="buddy_ping"}
-    valueExpr: 'result == 1.0 ? "up" : "down"'
-    colorExpr: 'result == 1.0 ? "brightgreen" : "red"'
-    icon: si:ubiquiti
-
-  - title: Status Page
-    id: buddy_status_page
-    query: gatus_results_endpoint_success{key="buddy_status-page"}
-    valueExpr: 'result == 1.0 ? "up" : "down"'
-    colorExpr: 'result == 1.0 ? "brightgreen" : "red"'
-    icon: si:statuspage
-
-  - title: Alertmanager
-    id: buddy_heartbeat
-    query: gatus_results_endpoint_success{key="buddy_heartbeat"}
-    valueExpr: 'result == 1.0 ? "up" : "down"'
-    colorExpr: 'result == 1.0 ? "brightgreen" : "red"'
-    icon: si:prometheus

--- a/kubernetes/apps/observability/kromgo/app/resources/config.yaml
+++ b/kubernetes/apps/observability/kromgo/app/resources/config.yaml
@@ -64,3 +64,24 @@ badges:
     id: cluster_alert_count
     query: alertmanager_alerts{state="active"} - 1 # Ignore Watchdog
     colorExpr: 'colorScale(result, [1.0], ["green", "red"])'
+
+  - title: Home Internet
+    id: buddy_ping
+    query: gatus_results_endpoint_success{key="buddy_ping"}
+    valueExpr: 'result == 1.0 ? "up" : "down"'
+    colorExpr: 'result == 1.0 ? "brightgreen" : "red"'
+    icon: si:ubiquiti
+
+  - title: Status Page
+    id: buddy_status_page
+    query: gatus_results_endpoint_success{key="buddy_status-page"}
+    valueExpr: 'result == 1.0 ? "up" : "down"'
+    colorExpr: 'result == 1.0 ? "brightgreen" : "red"'
+    icon: si:statuspage
+
+  - title: Alertmanager
+    id: buddy_heartbeat
+    query: gatus_results_endpoint_success{key="buddy_heartbeat"}
+    valueExpr: 'result == 1.0 ? "up" : "down"'
+    colorExpr: 'result == 1.0 ? "brightgreen" : "red"'
+    icon: si:prometheus

--- a/kubernetes/apps/observability/kromgo/ks.yaml
+++ b/kubernetes/apps/observability/kromgo/ks.yaml
@@ -13,7 +13,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_STATUS: "404"
   prune: true
   retryInterval: 2m
   sourceRef:


### PR DESCRIPTION
## Summary

- **Fix 404**: v0.14.0 changed the badge endpoint from `/<id>` to `/badges/<id>` — update gatus health check annotation accordingly
- **Clean up**: Remove dead `GATUS_STATUS: "404"` substitution from `ks.yaml` (was never wired to anything)
- **Buddy badges**: Add home internet, status page, and alertmanager badges sourced from `gatus_results_endpoint_success` Prometheus metrics

## Buddy badges setup (required for last three badges to work)

The buddy badges query `gatus_results_endpoint_success{key="buddy_*"}` metrics. These come from a **separate Gatus instance** running outside the cluster (a "buddy" device — e.g. Raspberry Pi, VPS) with this config:

| Endpoint | Gatus key | What it monitors |
|---|---|---|
| `icmp://${BUDDY_DDNS_HOSTNAME}` | `buddy_ping` | Home internet connectivity |
| `https://${BUDDY_STATUS_HOSTNAME}` | `buddy_status-page` | Status page availability |
| External heartbeat | `buddy_heartbeat` | Alertmanager dead man's switch |

That Gatus instance needs its `/metrics` scraped by your Prometheus. Until then, the buddy badges will show an error state.

## Test plan

- [ ] Verify `https://kromgo.pipitonelabs.com/badges/talos_version` returns 200
- [ ] Confirm gatus shows kromgo as UP
- [ ] Buddy badges show error until infrastructure is wired up (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)