### PR TITLE
feat(authentik): add budget-app OIDC blueprint

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprint-budget.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprint-budget.yaml
@@ -1,0 +1,64 @@
+---
+# Authentik blueprint for budget-app OIDC, mounted into /blueprints by the chart
+# (see helmrelease.yaml: blueprints.configMaps). Authentik discovers + applies it.
+#
+# budget-app is a STANDARD confidential OIDC client (Auth.js / next-auth v5,
+# provider "authentik"). Unlike tradeforge (HS256, custom PostgREST role claim),
+# this provider signs tokens RS256 with the Authentik self-signed key and uses the
+# default openid/email/profile scopes. client_id/secret come from env
+# (BUDGET_OIDC_*), provided via the authentik-secret ExternalSecret (1Password item
+# "budget"). Auth.js callback: https://budget.pipitonelabs.com/api/auth/callback/authentik
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-blueprint-budget
+data:
+  budget.yaml: |
+    version: 1
+    metadata:
+      name: budget-oidc
+    entries:
+      - id: budget-provider
+        model: authentik_providers_oauth2.oauth2provider
+        identifiers:
+          name: budget
+        attrs:
+          client_type: confidential
+          client_id: !Env BUDGET_OIDC_CLIENT_ID
+          client_secret: !Env BUDGET_OIDC_CLIENT_SECRET
+          sub_mode: user_uuid
+          access_token_validity: hours=4
+          grant_types:
+            - authorization_code
+            - refresh_token
+          # RS256: Authentik signs id/access tokens with the self-signed keypair;
+          # Auth.js validates via the provider's JWKS discovery endpoint.
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, provider-authorization-implicit-consent]]
+          authentication_flow: !Find [authentik_flows.flow, [slug, authentication-flow]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, invalidation-flow]]
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+          redirect_uris:
+            - matching_mode: strict
+              url: https://budget.pipitonelabs.com/api/auth/callback/authentik
+      - id: budget-app
+        model: authentik_core.application
+        identifiers:
+          slug: budget
+        attrs:
+          name: Budget
+          provider: !KeyOf budget-provider
+          meta_launch_url: https://budget.pipitonelabs.com/
+          open_in_new_tab: true
+      # Restrict access to the "Self Hosted" group (your account must be a member)
+      - id: budget-access
+        model: authentik_policies.policybinding
+        identifiers:
+          target: !KeyOf budget-app
+          group: !Find [authentik_core.group, [name, "Self Hosted"]]
+          order: 0
+        attrs:
+          enabled: true

--- a/kubernetes/apps/security/authentik/app/externalsecret.yaml
+++ b/kubernetes/apps/security/authentik/app/externalsecret.yaml
@@ -20,8 +20,13 @@ spec:
         # TradeForge OIDC (consumed by the tradeforge blueprint via !Env)
         TRADEFORGE_JWT_SECRET: '{{ .JWT_SECRET }}'
         TRADEFORGE_OIDC_CLIENT_ID: '{{ .oidc_client_id }}'
+        # budget-app OIDC (consumed by the budget blueprint via !Env)
+        BUDGET_OIDC_CLIENT_ID: '{{ .BUDGET_OIDC_CLIENT_ID }}'
+        BUDGET_OIDC_CLIENT_SECRET: '{{ .BUDGET_OIDC_CLIENT_SECRET }}'
   dataFrom:
   - extract:
       key: authentik
   - extract:
       key: tradeforge
+  - extract:
+      key: budget

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -34,6 +34,7 @@ spec:
     blueprints:
       configMaps:
         - authentik-blueprint-tradeforge
+        - authentik-blueprint-budget
     global:
       podAnnotations:
         secret.reloader.stakater.com/reload: authentik-secret

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: security
 resources:
   - ./blueprint-tradeforge.yaml
+  - ./blueprint-budget.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml


### PR DESCRIPTION
## What

Provisions an Authentik OIDC application for **budget-app** via an Authentik **blueprint**, mirroring the existing `tradeforge` pattern.

- `blueprint-budget.yaml` — standard **confidential** OIDC provider (RS256 via the Authentik self-signed keypair, `openid`/`email`/`profile` scopes), application slug `budget`, redirect URI `https://budget.pipitonelabs.com/api/auth/callback/authentik` (strict), restricted to the **Self Hosted** group.
- `externalsecret.yaml` — injects `BUDGET_OIDC_CLIENT_ID` / `BUDGET_OIDC_CLIENT_SECRET` from the 1Password item `budget` (vault `Kubernetes`).
- `helmrelease.yaml` + `kustomization.yaml` — register the `authentik-blueprint-budget` ConfigMap.

## Why

budget-app (a self-hosted envelope-budgeting app, Auth.js v5) authenticates household members via the existing Authentik SSO.

## Prerequisite (already done)

1Password item `budget` exists in the `Kubernetes` vault with `BUDGET_OIDC_CLIENT_ID`, `BUDGET_OIDC_CLIENT_SECRET` (plus `AUTH_SECRET` and `postgres_password` for the app's own ExternalSecret later).

## On merge

Flux reconciles `security/authentik` → the `authentik-secret` ExternalSecret picks up the `budget` item → Authentik (rolled by the stakater reload annotation) applies the blueprint → the **Budget** OIDC app appears.

## Validation

`kubectl kustomize kubernetes/apps/security/authentik/app` builds cleanly; the inner `budget.yaml` blueprint parses (3 entries: provider, application, access policy binding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)