### PR TITLE
Fix: correct Authentik OIDC issuer slug from budget-app to budget

### DIFF
--- a/kubernetes/apps/budget/app/externalsecret.yaml
+++ b/kubernetes/apps/budget/app/externalsecret.yaml
@@ -25,7 +25,7 @@ spec:
         AUTH_AUTHENTIK_ID: "{{ .BUDGET_OIDC_CLIENT_ID }}"
         AUTH_AUTHENTIK_SECRET: "{{ .BUDGET_OIDC_CLIENT_SECRET }}"
         # Trailing slash is byte-identical to the Authentik provider issuer URL.
-        AUTH_AUTHENTIK_ISSUER: "https://sso.pipitonelabs.com/application/o/budget-app/"
+        AUTH_AUTHENTIK_ISSUER: "https://sso.pipitonelabs.com/application/o/budget/"
   dataFrom:
     - extract:
         key: budget


### PR DESCRIPTION
The Authentik application was created with slug `budget` (not `budget-app`), so the discovery doc is at `/application/o/budget/` not `/application/o/budget-app/`. Fixes the "unexpected HTTP status code" Auth.js error on sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)