### PR TITLE
chore: bump budget-app digest (delete budgets + Plaid sync)

### DIFF
--- a/kubernetes/apps/budget/app/helmrelease.yaml
+++ b/kubernetes/apps/budget/app/helmrelease.yaml
@@ -47,7 +47,7 @@ spec:
               repository: ghcr.io/pipitonelabs/budget-app
               # Digest-pinned: Renovate bumps this on each new migrate-latest push.
               # Placeholder digest — non-deployable until first real image is pushed.
-              tag: migrate-latest@sha256:dc103109d06baf263201cd55852cae0a633aee66b94e3c7650ab8d6b6937e0ae
+              tag: migrate-latest@sha256:bafec7aec3dd65ed864b3aa7969308d632b22e72fdf0ae2017ca688ae63d0910
             env:
               DATABASE_URL:
                 valueFrom:
@@ -60,7 +60,7 @@ spec:
               repository: ghcr.io/pipitonelabs/budget-app
               # Digest-pinned: Renovate bumps this on each new latest push.
               # Placeholder digest — non-deployable until first real image is pushed.
-              tag: latest@sha256:ecd0c4427c7c556b609b039ca8081a517767b3c44b597e76f7bd7b486b20c3a4
+              tag: latest@sha256:5869f99dceb84c48c5a97b7b25b5c4c072f0b162cf8c04d987e2cea9f6b10f7a
             env:
               DATABASE_URL:
                 valueFrom:


### PR DESCRIPTION
Bumps both app and migrate images to the build from PR pipitonelabs/budget-app#21.