### PR TITLE
fix(authentik): increase server probe timeouts to 10s

### DIFF
--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -81,6 +81,10 @@ spec:
       autoscaling:
         enabled: true
         minReplicas: 1
+      livenessProbe:
+        timeoutSeconds: 10
+      readinessProbe:
+        timeoutSeconds: 10
       resources:
         requests:
           cpu: 200m


### PR DESCRIPTION
## Summary

- Authentik server readiness and liveness probes were intermittently timing out (×16 and ×13 respectively over a 9h window)
- Root cause: the chart default `timeout=3s` is too tight — normal health endpoint responses are 14–111ms but occasional DB/Redis latency spikes push past 3s
- Increases both probe timeouts to 10s; the pod never actually restarted (failureThreshold absorbed the spikes) so this is a hardening fix

## Test plan

- [ ] Confirm HelmRelease reconciles successfully after merge
- [ ] Verify no `Unhealthy` probe warning events in `security` namespace for 30+ minutes post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jaMMTHyY49NmF71BPpE7s