### PR TITLE
feat(budget): deploy YNAB migration import

### DIFF
--- a/kubernetes/apps/budget/app/helmrelease.yaml
+++ b/kubernetes/apps/budget/app/helmrelease.yaml
@@ -46,8 +46,7 @@ spec:
             image:
               repository: ghcr.io/pipitonelabs/budget-app
               # Digest-pinned: Renovate bumps this on each new migrate-latest push.
-              # Placeholder digest — non-deployable until first real image is pushed.
-              tag: migrate-latest@sha256:6b01117e93cf1392596849040db2bd060ec1b3a2d30a20bd07be8fa9ec672538
+              tag: migrate-latest@sha256:c060f26f34e4480894ae7a36e041ed7f2bfe6fef9a96270431ba1be19edd10bd
             env:
               DATABASE_URL:
                 valueFrom:
@@ -59,8 +58,7 @@ spec:
             image:
               repository: ghcr.io/pipitonelabs/budget-app
               # Digest-pinned: Renovate bumps this on each new latest push.
-              # Placeholder digest — non-deployable until first real image is pushed.
-              tag: latest@sha256:8318c5add88a7bac3d18119d4cdb9044c2099b87de96f3291e0dd8a4fe13b8c3
+              tag: latest@sha256:dceb27f43b1fa5cfe66e81961a1b99fe6ef70c7b3e9e29c3a4e0e229985118d7
             env:
               DATABASE_URL:
                 valueFrom:


### PR DESCRIPTION
Bumps the budget-app image digests to the new build that includes the YNAB migration import (Plan.csv assigned amounts, account-type mapping, system categories, transfer linking). Built from budget-app#118.

- app: `sha256:dceb27f4…`
- migrate: `sha256:c060f26f…`