### PR TITLE
fix: increase authentik-worker max replicas to 10

### DIFF
--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -98,7 +98,7 @@ spec:
       autoscaling:
         enabled: true
         minReplicas: 1
-        maxReplicas: 6
+        maxReplicas: 10
       resources:
         requests:
           cpu: 200m


### PR DESCRIPTION
## Summary
Increase the authentik-worker HPA max replicas from 6 to 10 to resolve the KubeHpaMaxedOut alert.

The worker pods are hitting the replica limit while CPU utilization is at 54% (above the 50% target threshold). This prevents the HPA from scaling up further.

## Test plan
- Verify the alert clears after Flux syncs this change
- Monitor authentik-worker scaling behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)