### PR TITLE
fix: revert kromgo to 0.14.12 (0.15.0 has breaking changes)

### DIFF
--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/kromgo
-              tag: 0.15.0@sha256:f3c01a0624c95db0f50a65ef901661774da5d2922a3187a2741e7149dee45f2a
+              tag: 0.14.12@sha256:f25f94610ba3b7e71753d3a33fdd9c47a2d94aab0b16eac15d0e53cfe52bf4fe
             env:
               PROMETHEUS_URL: http://prometheus-operated.observability.svc.cluster.local:9090
               HEALTH_PORT: &healthPort 8080


### PR DESCRIPTION
## Summary
- Reverts #2018, which bumped kromgo `0.14.12 → 0.15.0`
- 0.15.0 introduces breaking changes (per upstream release notes) that our HelmRelease doesn't account for:
  - All env vars now require a `KROMGO_` prefix, so our `PROMETHEUS_URL` var is no longer recognized → container exits with `"error":"no prometheus url provided"`
  - Legacy `/-/health` and `/-/ready` aliases dropped
  - Health now served on the main port instead of the separate health port, breaking our probe/port split
- Cluster was already crash-looping on the new ReplicaSet; the old (0.14.12) pods kept serving traffic and Flux had already auto-rolled-back the HelmRelease a couple times.

We can re-attempt 0.15.0 later once the HelmRelease is updated for the new env var prefix, port, and probe scheme.

## Test plan
- [ ] Flux reconciles kromgo back to 0.14.12
- [ ] kromgo pods report 1/1 Ready, no crash loop
- [ ] `/-/ready` responds on the health port again