### PR TITLE
fix(rook-ceph): raise HelmRelease timeout to 30m

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -21,6 +21,7 @@ spec:
     kind: OCIRepository
     name: rook-ceph-cluster
   interval: 1h
+  timeout: 30m
   values:
     monitoring:
       enabled: true


### PR DESCRIPTION
## Summary
- Renovate PR #2027 bumped the rook-ceph chart v1.20.1 → v1.20.2, which changed the default Ceph image tag v20.2.1 → v20.2.2.
- Rook rolls mon upgrades one at a time; Flux's default 5m HelmRelease timeout was too short to let that finish.
- The upgrade timed out mid-rollout (2/3 mons already on v20.2.2), Flux auto-rolled back to v1.20.1, and this repeated 11 times.
- `mon-f` got stuck: its on-disk store picked up an incompat feature bit (`nvmeof beacon diff`) synced from the v20.2.2 quorum, which the old v20.2.1 binary can't read — permanent CrashLoopBackOff, cluster HEALTH_WARN (1/3 mons down), CephFilesystem reconcile blocked.

## Fix
- Set `spec.timeout: 30m` on the `rook-ceph-cluster` HelmRelease so the rolling mon upgrade has room to complete instead of getting killed and rolled back mid-flight.

## Test plan
- [ ] Merge and let Flux reconcile
- [ ] Confirm `ceph status` returns to `HEALTH_OK` with 3/3 mons in quorum, all on v20.2.2
- [ ] Confirm `rook-ceph-mon-f` pod is `Running` with 0 further restarts
- [ ] Confirm CephFilesystem/CephCluster reconcile without errors in the rook-ceph-operator logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)